### PR TITLE
[Feat] CHAT_001 - 채팅 참여 연관 관계 및 엔티티 추가

### DIFF
--- a/backend/src/main/java/minionz/backend/chat_participation/model/ChatParticipation.java
+++ b/backend/src/main/java/minionz/backend/chat_participation/model/ChatParticipation.java
@@ -1,0 +1,37 @@
+package minionz.backend.chat_participation.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import minionz.backend.chat_room.model.ChatRoom;
+import minionz.backend.message.model.Message;
+import minionz.backend.user.model.User;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class ChatParticipation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long chatParticipationId;
+
+    // Message 1 : N
+    @OneToMany(mappedBy = "chatParticipation", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Message> messages = new ArrayList<>();
+
+    // User N : 1
+    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    // ChatRoom N : 1
+    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JoinColumn(name = "chatRoom_id")
+    private ChatRoom chatRoom;
+
+}


### PR DESCRIPTION
## 연관된 이슈
CHAT_001 - 채팅방 생성 기능 #2
<br>

## 작업 내용
- 유저와 채팅방 연관 관계인 M:N은 DB에서 표현하기 위해 연결 테이블인 채팅 참여 테이블을 생성하였다. 
- 메세지:채팅참여, 채팅참여:유저, 채팅방:채팅참여 의 관계를 설정 했다. 

<br> 

## 전달 사항
채팅참여는 id값 빼고는 갖고 있는 속성값이 없기 때문에 수정 사항 없을 거 같습니당.