### PR TITLE
[Feat] 공통 타임스탬프 관리용 BaseEntity 구현

### DIFF
--- a/backend/src/main/java/minionz/backend/common/BaseEntity.java
+++ b/backend/src/main/java/minionz/backend/common/BaseEntity.java
@@ -1,0 +1,24 @@
+package minionz.backend.common;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(insertable = false)
+    private LocalDateTime modifiedAt;
+
+}


### PR DESCRIPTION
## 연관된 이슈

<br>

## 작업 내용
- 공통 타임스탬프 관리용 BaseEntity 을 만들어서 createdAt, modifiedAt 값을 extends해서 사용 할 수 있도록 함 
<br> 

## 전달 사항
extends BaseEntity <- 해서 사용하시면 될 것 같습니당. 삭제 시간 같은 거는 없는 곳이 더 많아서 개인적으로 관리해요 ,, !