### PR TITLE
[Feat] CORS 및 WebSocket 설정 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -49,6 +49,8 @@ dependencies {
     testImplementation 'org.springframework.kafka:spring-kafka-test'
     //swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+    // webSocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/minionz/backend/config/WebConfig.java
+++ b/backend/src/main/java/minionz/backend/config/WebConfig.java
@@ -1,0 +1,23 @@
+package minionz.backend.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${address.domain}")
+    private String[] domains; // 허용할 주소 나중에 설정하기 cors 에러
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins(domains)
+                .allowedMethods("GET", "POST", "PATCH", "DELETE")
+                .allowedHeaders("Authorization", "Content-Type")
+                .allowCredentials(true)
+                .maxAge(3600);
+    }
+}

--- a/backend/src/main/java/minionz/backend/config/WebSocketConfig.java
+++ b/backend/src/main/java/minionz/backend/config/WebSocketConfig.java
@@ -1,0 +1,25 @@
+package minionz.backend.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/chat")
+                .setAllowedOriginPatterns("*") // 모든 도메인에서의 CORS 허용
+                .withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/sub");
+        registry.setApplicationDestinationPrefixes("/pub");
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,1 +1,52 @@
-spring.application.name=backend
+server:
+  port: ${PORT}
+spring:
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: org.mariadb.jdbc.Driver
+
+  jpa:
+    defer-datasource-initialization: true
+    database-platform: org.hibernate.dialect.MariaDBDialect
+    hibernate:
+      ddl-auto: ${DDL_TYPE}
+    properties:
+      hibernate:
+        format_sql: true
+
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          starttls:
+            enable: true
+            required: true
+          auth: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.orm.jdbc.bind: trace
+
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESSKEY}
+      secret-key: ${AWS_SECRETKEY}
+    region:
+      static: ${AWS_REGION}
+      auto: false
+    stack:
+      auto: false
+    s3:
+      bucket: ${S3_BUCKET}
+


### PR DESCRIPTION
## 연관된 이슈
#2 
<br>

## 작업 내용
- WebConfig : 
  - cors 설정을 추가해서 클라이언트 도메인에 대한 접근을 허용하도록 했습니다. 
  - 허용된 도메인은 `address.domain` 로 환경 변수에서 설정 되게 했습니다. 
  -  `GET`, `POST`, `PATCH`, `DELETE` 메서드와 `Authorization`, `Content-Type` 헤더를 지원하도록 했습니다.
- WebSocketConfig: 
  - WebSocket과 STOMP 설정을 추가하여 실시간 메시징을 지원하도록 했습니다. 
  - `/chat` 엔드포인트를 등록하고, 모든 도메인에서의 접근을 허용합니다.
  - 메시지 브로커 설정을 통해 `/sub` 경로로 구독 및 `/pub` 경로로 메시지 전송을 지원합니다.
- application.yml:
  - 환경 변수 처리해서 올려뒀습니다. 필요하신 부분은 추가 해 주시면 됩니다.
- build.gradle에 WebSocket이 없어서 추가 해 뒀습니다.
<br> 

## 전달 사항
 `address.domain`  이 부분은 yml에 추후에 추가 할 예정입니다. 현재 올리는 yml 에는 없습니다. 