### PR TITLE
[Feat] CHAT_001 - kafka Config 추가 [#2, #20]

### DIFF
--- a/backend/src/main/java/minionz/backend/chat/chat_participation/model/ChatParticipation.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_participation/model/ChatParticipation.java
@@ -1,9 +1,9 @@
-package minionz.backend.chat_participation.model;
+package minionz.backend.chat.chat_participation.model;
 
 import jakarta.persistence.*;
 import lombok.*;
-import minionz.backend.chat_room.model.ChatRoom;
-import minionz.backend.message.model.Message;
+import minionz.backend.chat.message.model.Message;
+import minionz.backend.chat.chat_room.model.ChatRoom;
 import minionz.backend.user.model.User;
 
 import java.util.ArrayList;

--- a/backend/src/main/java/minionz/backend/chat/chat_room/model/ChatRoom.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_room/model/ChatRoom.java
@@ -1,8 +1,8 @@
-package minionz.backend.chat_room.model;
+package minionz.backend.chat.chat_room.model;
 
 import jakarta.persistence.*;
 import lombok.*;
-import minionz.backend.chat_participation.model.ChatParticipation;
+import minionz.backend.chat.chat_participation.model.ChatParticipation;
 import minionz.backend.common.BaseEntity;
 
 import java.time.LocalDateTime;

--- a/backend/src/main/java/minionz/backend/chat/message/model/Message.java
+++ b/backend/src/main/java/minionz/backend/chat/message/model/Message.java
@@ -1,8 +1,8 @@
-package minionz.backend.message.model;
+package minionz.backend.chat.message.model;
 
 import jakarta.persistence.*;
 import lombok.*;
-import minionz.backend.chat_participation.model.ChatParticipation;
+import minionz.backend.chat.chat_participation.model.ChatParticipation;
 
 import java.time.LocalDateTime;
 

--- a/backend/src/main/java/minionz/backend/chat/message/model/MessageStatus.java
+++ b/backend/src/main/java/minionz/backend/chat/message/model/MessageStatus.java
@@ -1,4 +1,4 @@
-package minionz.backend.message.model;
+package minionz.backend.chat.message.model;
 
 public enum MessageStatus {
     UNREAD,

--- a/backend/src/main/java/minionz/backend/chat/message/model/MessageType.java
+++ b/backend/src/main/java/minionz/backend/chat/message/model/MessageType.java
@@ -1,4 +1,4 @@
-package minionz.backend.message.model;
+package minionz.backend.chat.message.model;
 
 public enum MessageType {
     TEXT,

--- a/backend/src/main/java/minionz/backend/config/kafka/KafkaConstants.java
+++ b/backend/src/main/java/minionz/backend/config/kafka/KafkaConstants.java
@@ -1,0 +1,7 @@
+package minionz.backend.config.kafka;
+
+import java.util.UUID;
+
+public class KafkaConstants {
+    public static final String GROUP_ID = UUID.randomUUID().toString();
+}

--- a/backend/src/main/java/minionz/backend/config/kafka/KafkaConsumerConfig.java
+++ b/backend/src/main/java/minionz/backend/config/kafka/KafkaConsumerConfig.java
@@ -1,0 +1,61 @@
+package minionz.backend.config.kafka;
+
+import minionz.backend.chat.message.model.request.MessageRequest;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableKafka
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Value("${spring.kafka.producer.bootstrap-servers}")
+    private String kafkaBroker;
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, MessageRequest> kafkaListenerContainerFactory() {
+        // 카프카에서 비동기적으로 메세지를 수신하는 리스너 컨테이너를 생성.
+        // 아래에서 생성 된 consumerFactory 를 설정한다.
+        ConcurrentKafkaListenerContainerFactory<String, MessageRequest> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        // consumerFactory 를 설정하는 곳 -> 나중에 수신하는 메소드가 있는 곳으로 간다.
+        return factory;
+    }
+
+    @Bean
+    public ConsumerFactory<String, MessageRequest> consumerFactory() {
+        // kafka 에서 메세지를 가져오는 역할을 한다 -> string 타입의 키와 MessageRequest 타입의 값을 가진
+        // 메세지를 처리할 수 있는 consumerFactory 를 생성.
+        return new DefaultKafkaConsumerFactory<>(consumerConfigurations(), new StringDeserializer(), new JsonDeserializer<>(MessageRequest.class));
+    }
+
+    @Bean
+    public Map<String, Object> consumerConfigurations() {
+        Map<String, Object> config = new HashMap<>();
+        // hashmap 을 통해서 빈 설정 맵을 만들어서 kafka 에 필요한 설정들을 put 하기.
+
+        JsonDeserializer<MessageRequest> deserializer = new JsonDeserializer<>(MessageRequest.class);
+        deserializer.setRemoveTypeHeaders(false);
+        deserializer.addTrustedPackages("*");
+        deserializer.setUseTypeMapperForKey(true);
+
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaBroker);
+        config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, deserializer);
+        config.put(ConsumerConfig.GROUP_ID_CONFIG, KafkaConstants.GROUP_ID);
+        config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+
+        return config;
+    }
+}
+

--- a/backend/src/main/java/minionz/backend/config/kafka/KafkaProducerConfig.java
+++ b/backend/src/main/java/minionz/backend/config/kafka/KafkaProducerConfig.java
@@ -1,0 +1,48 @@
+package minionz.backend.config.kafka;
+
+import minionz.backend.chat.message.model.request.MessageRequest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableKafka
+@Configuration
+public class KafkaProducerConfig {
+    // ProducerFactory 와 KafkaTemplate 을 설정하여 Kafka 에 메시지를 전송할 준비
+
+    @Value("${spring.kafka.producer.bootstrap-servers}")
+    private String kafkaBroker;
+
+    @Bean
+    // 2) 아래에서 구성한대로 Kafka Producer 를 생성해서 3으로 준다
+    public ProducerFactory<String, MessageRequest> producerFactory() {
+        return new DefaultKafkaProducerFactory<>(kafkaProducerConfiguration());
+    }
+
+    @Bean
+    // 1) Kafka 프로듀서에 필요한 설정들을 HashMap 으로 정의해서 put 으로 추가해서 2로 전달
+    public Map<String, Object> kafkaProducerConfiguration() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaBroker);
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return config;
+    }
+
+    @Bean
+    // 3) producerFactory 를 사용하여 생성한 것을 kafka 토픽을 통해 메세지를 전송
+    public KafkaTemplate<String, MessageRequest> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}
+

--- a/backend/src/main/java/minionz/backend/config/web/WebConfig.java
+++ b/backend/src/main/java/minionz/backend/config/web/WebConfig.java
@@ -1,4 +1,4 @@
-package minionz.backend.config;
+package minionz.backend.config.web;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;

--- a/backend/src/main/java/minionz/backend/config/web/WebSocketConfig.java
+++ b/backend/src/main/java/minionz/backend/config/web/WebSocketConfig.java
@@ -1,4 +1,4 @@
-package minionz.backend.config;
+package minionz.backend.config.web;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;

--- a/backend/src/main/java/minionz/backend/user/model/User.java
+++ b/backend/src/main/java/minionz/backend/user/model/User.java
@@ -2,7 +2,7 @@ package minionz.backend.user.model;
 
 import jakarta.persistence.*;
 import lombok.*;
-import minionz.backend.chat_participation.model.ChatParticipation;
+import minionz.backend.chat.chat_participation.model.ChatParticipation;
 import minionz.backend.scrum.issue_participation.model.IssueParticipation;
 import minionz.backend.scrum.meeting_participation.model.MeetingParticipation;
 import minionz.backend.scrum.sprint_participation.model.SprintParticipation;

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -34,6 +34,13 @@ spring:
           timeout: 5000
           writetimeout: 5000
 
+  kafka:
+    producer:
+      bootstrap-servers: ${KAFKA_SERVER}
+    consumer:
+      bootstrap-servers: ${KAFKA_SERVER}
+    bootstrap-servers: ${KAFKA_SERVER}
+
 logging:
   level:
     org.hibernate.SQL: debug


### PR DESCRIPTION
## 연관된 이슈
#2 #20
<br>

## 작업 내용
- 폴더 구조 변경 했습니다. 
  - chat 안에 [ message, chat_room, chat_participation ] 을 넣어서 체계적으로 관리하도록 했습니다.
- config에 kafka 폴더를 만들어서 안에 관련 config 들을 구현 후 넣어놨습니다.
  - KafkaConstants: `GROUP_ID` 를 uuid로 관리 하도록 만들었습니다.
  - KafkaConsumerConfig: kafka에서 메세지를 가지고 오는 역할을 하는 `consumerFactory` 를 생성하고, `consumer` `kafka`에 필요한 설정들을 추가 했습니다.
  - KafkaProducerConfig: `ProducerFactory`와 `KafkaTemplate`을 설정하여 `Kafka`에 메세지를 전송할 준비하는 `Config`라고 생각 해 주시면 됩니다.
    - 이해를 위해 실행 순서 주석을 달아뒀으니 순서 참고 하시면 됩니다.
  


<br> 

## 전달 사항
`application.yml` 안에 `kafka server` 를 적어야 하는 칸을 추가 해 뒀습니다. 해당 관련 된 것들은 discord에 올려놓겠습니다. 필요하신 분들은 각자 `local.yml`에 추가해서 쓰시면 될 것 같습니다.! 