### PR TITLE
[Feat] SPRINT_001 - 스프린트 생성 기능 구현 [#86]

### DIFF
--- a/backend/src/main/java/minionz/backend/common/responses/BaseResponseStatus.java
+++ b/backend/src/main/java/minionz/backend/common/responses/BaseResponseStatus.java
@@ -34,6 +34,8 @@ public enum BaseResponseStatus {
     TASK_LABEL_CREATE_SUCCESS(true, 4003, "태스크 라벨 생성을 성공했습니다."),
     SPRINT_LABEL_READ_SUCCESS(true, 4004, "스프린트 라벨 조회를 성공했습니다."),
     TASK_LABEL_READ_SUCCESS(true, 4005, "태스크 라벨 조회를 성공했습니다."),
+    SPRINT_CREATE_SUCCESS(true, 4006, "스프린트 생성에 성공했습니다."),
+    SPRINT_READ_SUCCESS(true, 4007, "스프린트 조회에 성공했습니다."),
 
 
     WORKSPACE_ACCESS_DENIED(false, 4101, "워크스페이스에 접근 권한이 없습니다."),

--- a/backend/src/main/java/minionz/backend/scrum/label/LabelService.java
+++ b/backend/src/main/java/minionz/backend/scrum/label/LabelService.java
@@ -25,15 +25,11 @@ public class LabelService {
     private final WorkspaceRepository workspaceRepository;
     private final WorkspaceParticipationRepository workspaceParticipationRepository;
 
-    public void createSprintLabel(User user, CreateLabelRequest request) throws BaseException {
-        workspaceRepository.findById(request.getWorkspaceId()).orElseThrow(
-                () -> new BaseException(BaseResponseStatus.WORKSPACE_NOT_EXISTS)
-        );
 
-        if (workspaceParticipationRepository.findByWorkspaceWorkspaceIdAndUserUserId(request.getWorkspaceId(), user.getUserId()) == null) {
-            throw new BaseException(BaseResponseStatus.INVALID_ACCESS);
-        }
-        ;
+    public void createSprintLabel(User user, CreateLabelRequest request) throws BaseException {
+        workspaceParticipationRepository.findByWorkspaceWorkspaceIdAndUserUserId(request.getWorkspaceId(), user.getUserId()).orElseThrow(
+                () ->  new BaseException(BaseResponseStatus.INVALID_ACCESS)
+        );
 
         if (sprintLabelRepository.findByLabelName(request.getLabelName()) != null) {
             throw new BaseException(BaseResponseStatus.LABEL_ALREADY_EXISTS);
@@ -43,9 +39,9 @@ public class LabelService {
     }
 
     public List<ReadLabelResponse> readSprintLabel(User user, Long id) throws BaseException {
-        if (workspaceParticipationRepository.findByWorkspaceWorkspaceIdAndUserUserId(id, user.getUserId()) == null) {
-            throw new BaseException(BaseResponseStatus.INVALID_ACCESS);
-        }
+        workspaceParticipationRepository.findByWorkspaceWorkspaceIdAndUserUserId(id, user.getUserId()).orElseThrow(
+                () ->  new BaseException(BaseResponseStatus.INVALID_ACCESS)
+        );
 
         List<SprintLabel> labels = sprintLabelRepository.findByWorkspaceWorkspaceId(id);
 
@@ -62,14 +58,9 @@ public class LabelService {
     }
 
     public void createTaskLabel(User user, CreateLabelRequest request) throws BaseException {
-        workspaceRepository.findById(request.getWorkspaceId()).orElseThrow(
-                () -> new BaseException(BaseResponseStatus.WORKSPACE_NOT_EXISTS)
+        workspaceParticipationRepository.findByWorkspaceWorkspaceIdAndUserUserId(request.getWorkspaceId(), user.getUserId()).orElseThrow(
+                () ->  new BaseException(BaseResponseStatus.INVALID_ACCESS)
         );
-
-        if (workspaceParticipationRepository.findByWorkspaceWorkspaceIdAndUserUserId(request.getWorkspaceId(), user.getUserId()) == null) {
-            throw new BaseException(BaseResponseStatus.INVALID_ACCESS);
-        }
-        ;
 
         if (taskLabelRepository.findByLabelName(request.getLabelName()) != null) {
             throw new BaseException(BaseResponseStatus.LABEL_ALREADY_EXISTS);
@@ -79,9 +70,9 @@ public class LabelService {
     }
 
     public List<ReadLabelResponse> readTaskLabel(User user, Long id) throws BaseException {
-        if (workspaceParticipationRepository.findByWorkspaceWorkspaceIdAndUserUserId(id, user.getUserId()) == null) {
-            throw new BaseException(BaseResponseStatus.INVALID_ACCESS);
-        }
+        workspaceParticipationRepository.findByWorkspaceWorkspaceIdAndUserUserId(id, user.getUserId()).orElseThrow(
+                () ->  new BaseException(BaseResponseStatus.INVALID_ACCESS)
+        );
 
         List<TaskLabel> labels = taskLabelRepository.findByWorkspaceWorkspaceId(id);
 

--- a/backend/src/main/java/minionz/backend/scrum/sprint/SprintController.java
+++ b/backend/src/main/java/minionz/backend/scrum/sprint/SprintController.java
@@ -1,0 +1,28 @@
+package minionz.backend.scrum.sprint;
+
+import lombok.RequiredArgsConstructor;
+import minionz.backend.common.responses.BaseResponse;
+import minionz.backend.common.responses.BaseResponseStatus;
+import minionz.backend.scrum.sprint.model.request.CreateSprintRequest;
+import minionz.backend.user.model.User;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/sprint")
+public class SprintController {
+
+    private final SprintService sprintService;
+
+    @PostMapping("")
+    public BaseResponse<BaseResponseStatus> craeteSprint(@RequestBody CreateSprintRequest request){
+        User user = User.builder().userId(1L).build();
+
+        sprintService.createSprint(user, request);
+
+        return new BaseResponse<>(BaseResponseStatus.SPRINT_CREATE_SUCCESS);
+    }
+}

--- a/backend/src/main/java/minionz/backend/scrum/sprint/SprintRepository.java
+++ b/backend/src/main/java/minionz/backend/scrum/sprint/SprintRepository.java
@@ -1,0 +1,7 @@
+package minionz.backend.scrum.sprint;
+
+import minionz.backend.scrum.sprint.model.Sprint;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SprintRepository extends JpaRepository<Sprint, Long> {
+}

--- a/backend/src/main/java/minionz/backend/scrum/sprint/SprintService.java
+++ b/backend/src/main/java/minionz/backend/scrum/sprint/SprintService.java
@@ -1,0 +1,65 @@
+package minionz.backend.scrum.sprint;
+
+import lombok.RequiredArgsConstructor;
+import minionz.backend.common.exception.BaseException;
+import minionz.backend.common.responses.BaseResponseStatus;
+import minionz.backend.scrum.label.model.SprintLabel;
+import minionz.backend.scrum.label_select.SprintLabelSelectRepository;
+import minionz.backend.scrum.label_select.model.SprintLabelSelect;
+import minionz.backend.scrum.sprint.model.Sprint;
+import minionz.backend.scrum.sprint.model.SprintStatus;
+import minionz.backend.scrum.sprint.model.request.CreateSprintRequest;
+import minionz.backend.scrum.sprint_participation.SprintParticipationRepository;
+import minionz.backend.scrum.sprint_participation.model.SprintParticipation;
+import minionz.backend.scrum.workspace.WorkspaceRepository;
+import minionz.backend.scrum.workspace.model.Workspace;
+import minionz.backend.scrum.workspace_participation.WorkspaceParticipationRepository;
+import minionz.backend.user.model.User;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SprintService {
+    private final SprintRepository sprintRepository;
+    private final SprintParticipationRepository sprintParticipationRepository;
+    private final SprintLabelSelectRepository sprintLabelSelectRepository;
+    private final WorkspaceRepository workspaceRepository;
+    private final WorkspaceParticipationRepository workspaceParticipationRepository;  // final이 없으면 초기화 안됨. RequiredArgsConstructor로 의존성 주입 안됨. like const
+
+    public void createSprint(User user, CreateSprintRequest request) {
+//        user가 워크스페이스 내에 포함됐는지? 확인.
+        workspaceParticipationRepository.findByWorkspaceWorkspaceIdAndUserUserId(request.getWorkspaceId(), user.getUserId()).orElseThrow(
+                () ->  new BaseException(BaseResponseStatus.INVALID_ACCESS)
+        );
+
+        Sprint sprint = sprintRepository.save(Sprint
+                .builder()
+                .sprintTitle(request.getSprintTitle())
+                .sprintContents(request.getSprintContents())
+                .startDate(request.getStartDate())
+                .endDate(request.getEndDate())
+                .status(SprintStatus.TODO)
+                .workspace(Workspace.builder().workspaceId(request.getWorkspaceId()).build())
+                .build());
+
+//        TODO: 알람 보내야합니다!
+//        참여 테이블에 참가자들 추가
+        sprintParticipationRepository.save(SprintParticipation.builder().sprint(sprint).user(user).isManager(true).build());
+        request.getParticipants().forEach(participantId ->
+                sprintParticipationRepository.save(SprintParticipation
+                        .builder()
+                        .sprint(sprint)
+                        .user(User.builder().userId(participantId).build())
+                        .isManager(false)
+                        .build())
+        );
+
+//        스프린트 라벨이 존재하는지 검증하는 유효성 테스트 필요
+        request.getLabels().forEach(labelId ->
+                sprintLabelSelectRepository.save(SprintLabelSelect
+                        .builder()
+                        .sprintLabel(SprintLabel.builder().sprintLabelId(labelId).build())
+                        .sprint(sprint)
+                        .build()));
+    }
+}

--- a/backend/src/main/java/minionz/backend/scrum/sprint/model/request/CreateSprintRequest.java
+++ b/backend/src/main/java/minionz/backend/scrum/sprint/model/request/CreateSprintRequest.java
@@ -1,0 +1,19 @@
+package minionz.backend.scrum.sprint.model.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+@Getter
+public class CreateSprintRequest {
+    private Long workspaceId;
+    private String sprintTitle;
+    private String sprintContents;
+    private List<Long> labels;
+    private List<Long> participants;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+}

--- a/backend/src/main/java/minionz/backend/scrum/sprint_participation/SprintParticipationRepository.java
+++ b/backend/src/main/java/minionz/backend/scrum/sprint_participation/SprintParticipationRepository.java
@@ -1,0 +1,7 @@
+package minionz.backend.scrum.sprint_participation;
+
+import minionz.backend.scrum.sprint_participation.model.SprintParticipation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SprintParticipationRepository extends JpaRepository<SprintParticipation, Long> {
+}

--- a/backend/src/main/java/minionz/backend/scrum/workspace/WorkspaceController.java
+++ b/backend/src/main/java/minionz/backend/scrum/workspace/WorkspaceController.java
@@ -34,6 +34,6 @@ public class WorkspaceController {
 
         List<ReadWorkspaceResponse> readWorkspaceResponses = workspaceService.readAll(user);
 
-        return new BaseResponse<>(BaseResponseStatus.MY_WORKSPACE_READ_SUCCESS , readWorkspaceResponses);
+        return new BaseResponse<>(BaseResponseStatus.MY_WORKSPACE_READ_SUCCESS, readWorkspaceResponses);
     }
 }

--- a/backend/src/main/java/minionz/backend/scrum/workspace_participation/WorkspaceParticipationRepository.java
+++ b/backend/src/main/java/minionz/backend/scrum/workspace_participation/WorkspaceParticipationRepository.java
@@ -3,6 +3,8 @@ package minionz.backend.scrum.workspace_participation;
 import minionz.backend.scrum.workspace_participation.model.WorkspaceParticipation;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface WorkspaceParticipationRepository extends JpaRepository<WorkspaceParticipation,Long> {
-    WorkspaceParticipation findByWorkspaceWorkspaceIdAndUserUserId (Long workspaceId, Long userId);
+    Optional<WorkspaceParticipation> findByWorkspaceWorkspaceIdAndUserUserId (Long workspaceId, Long userId);
 }


### PR DESCRIPTION
## 연관된 이슈
#86 
<br>

## 작업 내용
- 워크스페이스에서 스프린트를 생성하는 기능을 구현했습니다.
- 스프린트를 생성하면 스프린트 참여 테이블에 참여자들이 추가되도록 구현했습니다.
- 스프린트 생성 시 전달받은 스프린트 라벨들을 스프린트 라벨 선택 테이블에 추가되도록 구현했습니다.
- 스프린트를 생성하는 유저가 워크스페이스 내에 존재하는 유저인지에 대한 유효성 검증을 마쳤습니다.
<br> 

## 전달 사항
- 알람기능 구현 후 스프린트에 참여된 유저에게 알람을 보내도록 추가 구현이 필요합니다.
- 추후 요청 데이터로 전달받은 스프린트 라벨이 실제 워크스페이스 내 존재하는 라벨인지에 대한 유효성 검증이 필요합니다.

close #86 
