### PR TITLE
[Feat] CHAT_001,003,005 그룹 채팅 메세지 보내기 및 채팅방 생성 [#2, #11, #20] 

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     //kafka
     implementation 'org.springframework.kafka:spring-kafka'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
     //swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
     //JWT TOKEN 로그인

--- a/backend/src/main/java/minionz/backend/chat/chat_participation/ChatParticipationRepository.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_participation/ChatParticipationRepository.java
@@ -1,0 +1,13 @@
+package minionz.backend.chat.chat_participation;
+
+import minionz.backend.chat.chat_participation.model.ChatParticipation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ChatParticipationRepository extends JpaRepository<ChatParticipation, Long> {
+    List<ChatParticipation> findByUser_UserId(Long userId);
+    Optional<ChatParticipation> findByChatRoom_ChatRoomIdAndUser_UserId(Long chatRoomId, Long userId);
+}
+

--- a/backend/src/main/java/minionz/backend/chat/chat_participation/model/ChatParticipation.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_participation/model/ChatParticipation.java
@@ -21,17 +21,17 @@ public class ChatParticipation {
     private Long chatParticipationId;
 
     // Message 1 : N
-    @OneToMany(mappedBy = "chatParticipation", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "chatParticipation", fetch = FetchType.LAZY)
     private List<Message> messages = new ArrayList<>();
 
     // User N : 1
-    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
     // ChatRoom N : 1
-    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    @JoinColumn(name = "chatRoom_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id")
     private ChatRoom chatRoom;
 
 }

--- a/backend/src/main/java/minionz/backend/chat/chat_room/ChatRoomController.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_room/ChatRoomController.java
@@ -1,0 +1,39 @@
+package minionz.backend.chat.chat_room;
+
+import lombok.RequiredArgsConstructor;
+import minionz.backend.chat.chat_room.model.request.CreateChatRoomRequest;
+import minionz.backend.chat.chat_room.model.request.CreatePersonalChatRoomRequest;
+import minionz.backend.chat.chat_room.model.response.CreateChatRoomResponse;
+import minionz.backend.chat.chat_room.model.response.CreatePersonalChatRoomResponse;
+import minionz.backend.chat.chat_room.model.response.ReadChatRoomResponse;
+import minionz.backend.common.responses.BaseResponse;
+import minionz.backend.common.responses.BaseResponseStatus;
+import minionz.backend.user.model.CustomSecurityUserDetails;
+import minionz.backend.user.model.User;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/chat")
+@RequiredArgsConstructor
+public class ChatRoomController {
+    private final ChatRoomService chatRoomService;
+
+    @PostMapping(value = "/room")
+    public BaseResponse<CreateChatRoomResponse> create(@AuthenticationPrincipal CustomSecurityUserDetails customUserDetails, @RequestBody CreateChatRoomRequest request) {
+        User user = customUserDetails.getUser();
+        CreateChatRoomResponse response = chatRoomService.create(user, request);
+        return new BaseResponse<>(BaseResponseStatus.CHATROOM_CREATE_SUCCESS, response);
+    }
+
+    @GetMapping(value = "/roomList")
+    public BaseResponse<List<ReadChatRoomResponse>> readRoomList(@AuthenticationPrincipal CustomSecurityUserDetails customUserDetails) {
+        User user = customUserDetails.getUser();
+        List<ReadChatRoomResponse> response = chatRoomService.roomList(user.getUserId());
+        return new BaseResponse<>(BaseResponseStatus.CHATROOM_LIST_SUCCESS, response);
+    }
+
+}

--- a/backend/src/main/java/minionz/backend/chat/chat_room/ChatRoomRepository.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_room/ChatRoomRepository.java
@@ -1,0 +1,7 @@
+package minionz.backend.chat.chat_room;
+
+import minionz.backend.chat.chat_room.model.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+}

--- a/backend/src/main/java/minionz/backend/chat/chat_room/ChatRoomService.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_room/ChatRoomService.java
@@ -1,0 +1,131 @@
+package minionz.backend.chat.chat_room;
+
+import lombok.RequiredArgsConstructor;
+import minionz.backend.chat.chat_participation.ChatParticipationRepository;
+import minionz.backend.chat.chat_participation.model.ChatParticipation;
+import minionz.backend.chat.chat_room.model.ChatRoom;
+import minionz.backend.chat.chat_room.model.request.CreateChatRoomRequest;
+import minionz.backend.chat.chat_room.model.response.CreateChatRoomResponse;
+import minionz.backend.chat.chat_room.model.response.ReadChatRoomResponse;
+import minionz.backend.chat.message.MessageRepository;
+import minionz.backend.chat.message.model.Message;
+import minionz.backend.chat.message.model.MessageStatus;
+import minionz.backend.common.responses.BaseResponse;
+import minionz.backend.common.responses.BaseResponseStatus;
+import minionz.backend.user.UserRepository;
+import minionz.backend.user.model.User;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.KafkaAdmin;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomService {
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatParticipationRepository chatParticipationRepository;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final KafkaAdmin kafkaAdmin;
+    private final MessageRepository messageRepository;
+    private final UserRepository userRepository;
+
+    public CreateChatRoomResponse create(User user, CreateChatRoomRequest request) {
+        ChatRoom chatRoom = createChatRoom(request);
+        saveChatParticipants(chatRoom, request.getParticipants());
+        String chatRoomIdStr = chatRoom.getChatRoomId().toString();
+
+        // Kafka 토픽과 메시지 전송
+        createKafkaTopic(chatRoomIdStr);
+        sendCreationMessage(chatRoomIdStr, "채팅방이 생성되었습니다.");
+
+        return buildCreateChatRoomResponse(chatRoom, request.getParticipants(), chatRoomIdStr);
+    }
+
+    // 채팅룸 리스트 조회
+    public List<ReadChatRoomResponse> roomList(Long userId) {
+        List<ChatParticipation> chatParticipations = chatParticipationRepository.findByUser_UserId(userId);
+
+        List<ReadChatRoomResponse> responseList = new ArrayList<>();
+
+        for (ChatParticipation participation : chatParticipations) {
+            ChatRoom chatRoom = participation.getChatRoom();
+
+            // 채팅방에서 가장 최근 메시지를 가져옴
+            Message latestMessage = findLatestMessage(chatRoom.getChatRoomId());
+            System.out.println(latestMessage.getMessageContents());
+
+            // 읽지 않은 메시지 수 계산
+            Long unreadMessagesCount = messageRepository.countUnreadMessagesByChatRoomIdAndUserId(
+                    chatRoom.getChatRoomId(), userId, MessageStatus.UNREAD);
+
+            ReadChatRoomResponse response = ReadChatRoomResponse.builder()
+                    .chatroomId(chatRoom.getChatRoomId())
+                    .chatRoomName(chatRoom.getChatRoomName())
+                    .messageContents(latestMessage != null ? latestMessage.getMessageContents() : "No messages")
+                    .createdAt(latestMessage != null ? latestMessage.getCreatedAt() : chatRoom.getCreatedAt())
+                    .UnreadMessages(unreadMessagesCount != null ? unreadMessagesCount.intValue() : 0)
+                    .build();
+
+            responseList.add(response);
+        }
+        return responseList;
+    }
+
+    private ChatRoom createChatRoom(CreateChatRoomRequest request) {
+        ChatRoom chatRoom = ChatRoom.builder()
+                .chatRoomName(request.getChatRoomName())
+                .build();
+        return chatRoomRepository.save(chatRoom);
+    }
+
+    private BaseResponse<Void> saveChatParticipants(ChatRoom chatRoom, List<Long> participantIds) {
+        for (Long participantId : participantIds) {
+            User participant = userRepository.findById(participantId)
+                    .orElse(null); // User가 null인 경우를 처리하기 위해
+            if (participant == null) {
+                return new BaseResponse<>(BaseResponseStatus.CHATROOM_CREATE_FAIL);
+            }
+            ChatParticipation chatParticipation = ChatParticipation.builder()
+                    .user(participant)
+                    .chatRoom(chatRoom)
+                    .build();
+            chatParticipationRepository.save(chatParticipation);
+        }
+        return new BaseResponse<>(BaseResponseStatus.CHATROOM_CREATE_SUCCESS);
+    }
+
+    private CreateChatRoomResponse buildCreateChatRoomResponse(ChatRoom chatRoom, List<Long> participants, String chatRoomIdStr) {
+        return CreateChatRoomResponse.builder()
+                .chatRoomId(chatRoom.getChatRoomId())
+                .chatRoomName(chatRoom.getChatRoomName())
+                .participants(participants)
+                .topic("chat-room-" + chatRoomIdStr)
+                .creationMessage("채팅방이 생성되었습니다.")
+                .build();
+    }
+
+    // 최신 메세지 하나만 가져오기
+    public Message findLatestMessage(Long chatRoomId) {
+        List<Message> messages = messageRepository.findLatestMessagesByChatRoomId(chatRoomId);
+        return messages.isEmpty() ? null : messages.get(0);
+    }
+
+    // 토픽 생성
+    private void createKafkaTopic(String chatRoomId) {
+        String topic = "chat-room-" + chatRoomId;
+        NewTopic newTopic = TopicBuilder.name(topic).build();
+        kafkaAdmin.createOrModifyTopics(newTopic);
+    }
+
+    // 메세지 전송
+    private void sendCreationMessage(String chatRoomId, String message) {
+        String topic = "chat-room-" + chatRoomId; // 채팅방 관련 토픽
+        kafkaTemplate.send(topic, message); // 메시지를 토픽으로 전송
+    }
+
+
+}

--- a/backend/src/main/java/minionz/backend/chat/chat_room/model/ChatRoom.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_room/model/ChatRoom.java
@@ -19,7 +19,6 @@ public class ChatRoom extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long chatRoomId;
-
     private String chatRoomName;
     private LocalDateTime deletedAt;
     private String fileType;
@@ -28,7 +27,7 @@ public class ChatRoom extends BaseEntity {
     private String fileName;
 
     // ChatParticipation 1 : N
-    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "chatRoom", fetch = FetchType.LAZY)
     private List<ChatParticipation> chatParticipations = new ArrayList<>();
 
 }

--- a/backend/src/main/java/minionz/backend/chat/chat_room/model/request/CreatePersonalChatRoomRequest.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_room/model/request/CreatePersonalChatRoomRequest.java
@@ -1,0 +1,16 @@
+package minionz.backend.chat.chat_room.model.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreatePersonalChatRoomRequest {
+
+    private Long receiverId;
+}
+

--- a/backend/src/main/java/minionz/backend/chat/chat_room/model/response/CreatePersonalChatRoomResponse.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_room/model/response/CreatePersonalChatRoomResponse.java
@@ -3,16 +3,12 @@ package minionz.backend.chat.chat_room.model.response;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.util.List;
-
 @Builder
 @Getter
-public class CreateChatRoomResponse {
-
+public class CreatePersonalChatRoomResponse {
     private Long chatRoomId;
     private String chatRoomName;
-    private List<Long> participants;
+    private Long senderId;
+    private Long receiverId;
     private String topic;
-    private String creationMessage;
-
 }

--- a/backend/src/main/java/minionz/backend/chat/chat_room/model/response/ReadChatRoomResponse.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_room/model/response/ReadChatRoomResponse.java
@@ -1,0 +1,17 @@
+package minionz.backend.chat.chat_room.model.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+public class ReadChatRoomResponse {
+    private Long chatroomId;
+    private String chatRoomName;
+    private String messageContents;
+    private LocalDateTime createdAt;
+    private Integer UnreadMessages;
+
+}

--- a/backend/src/main/java/minionz/backend/chat/message/MessageController.java
+++ b/backend/src/main/java/minionz/backend/chat/message/MessageController.java
@@ -1,0 +1,50 @@
+package minionz.backend.chat.message;
+
+import lombok.RequiredArgsConstructor;
+import minionz.backend.chat.message.model.request.MessageRequest;
+import minionz.backend.chat.message.model.request.PrivateMessageRequest;
+import minionz.backend.chat.message.model.response.MessageResponse;
+import minionz.backend.common.responses.BaseResponse;
+import minionz.backend.common.responses.BaseResponseStatus;
+import minionz.backend.user.model.CustomSecurityUserDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/message")
+@RequiredArgsConstructor
+public class MessageController {
+
+    private final MessageService messageService;
+
+    // 그룹 메세지 전송
+    @PostMapping("/send")
+    public BaseResponse<MessageResponse> sendMessage(@RequestBody MessageRequest request, @AuthenticationPrincipal CustomSecurityUserDetails userDetails) {
+        Long senderId = userDetails.getUser().getUserId();
+        MessageRequest updatedRequest = request.toBuilder()
+                .senderId(senderId)
+                .build();
+
+        MessageResponse response = messageService.sendMessage(updatedRequest.getChatRoomId(), updatedRequest);
+
+        return new BaseResponse<>(BaseResponseStatus.MESSAGE_SEND_SUCCESS, response);
+    }
+
+//    @PostMapping("/send")
+//    public BaseResponse<MessageResponse> sendPrivateMessage(@RequestBody PrivateMessageRequest request, @AuthenticationPrincipal CustomSecurityUserDetails userDetails) {
+//        // 보내는 사람의 ID를 설정
+//        Long senderId = userDetails.getUser().getUserId();
+//        PrivateMessageRequest updatedRequest = request.toBuilder()
+//                .senderId(senderId)
+//                .build();
+//
+//        // 개인 채팅방 전송 처리
+//        MessageResponse response = messageService.sendPrivateMessage(updatedRequest.getChatRoomId(), updatedRequest);
+//
+//        return new BaseResponse<>(BaseResponseStatus.MESSAGE_SEND_SUCCESS, response);
+//    }
+}
+

--- a/backend/src/main/java/minionz/backend/chat/message/MessageRepository.java
+++ b/backend/src/main/java/minionz/backend/chat/message/MessageRepository.java
@@ -1,0 +1,34 @@
+package minionz.backend.chat.message;
+
+import minionz.backend.chat.message.model.Message;
+import minionz.backend.chat.message.model.MessageStatus;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MessageRepository extends JpaRepository<Message, Long> {
+
+    @Query("SELECT COUNT(m) FROM Message m " +
+            "JOIN m.chatParticipation cp " +
+            "JOIN cp.chatRoom cr " +
+            "JOIN cp.user u " +
+            "WHERE cr.chatRoomId = :chatRoomId " +
+            "AND u.userId = :userId " +
+            "AND m.messageStatus = :status")
+    Long countUnreadMessagesByChatRoomIdAndUserId(Long chatRoomId,
+                                                  Long userId,
+                                                  MessageStatus status);
+
+    @Query("SELECT m FROM Message m WHERE m.chatParticipation.chatRoom.chatRoomId = :chatRoomId ORDER BY m.createdAt DESC")
+    List<Message> findLatestMessagesByChatRoomId(Long chatRoomId);
+
+
+
+
+
+}
+

--- a/backend/src/main/java/minionz/backend/chat/message/MessageService.java
+++ b/backend/src/main/java/minionz/backend/chat/message/MessageService.java
@@ -1,0 +1,88 @@
+package minionz.backend.chat.message;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import minionz.backend.chat.chat_participation.ChatParticipationRepository;
+import minionz.backend.chat.chat_participation.model.ChatParticipation;
+import minionz.backend.chat.chat_room.ChatRoomRepository;
+import minionz.backend.chat.message.model.Message;
+import minionz.backend.chat.message.model.MessageType;
+import minionz.backend.chat.message.model.request.MessageRequest;
+import minionz.backend.chat.message.model.response.MessageResponse;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MessageService {
+
+    private final MessageRepository messageRepository;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatParticipationRepository chatParticipationRepository;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public MessageResponse sendMessage(Long chatRoomId, MessageRequest request) {
+        ChatParticipation participation = chatParticipationRepository.findByChatRoom_ChatRoomIdAndUser_UserId(chatRoomId, request.getSenderId())
+                .orElseThrow(() -> new RuntimeException("ChatParticipation not found"));
+
+        Message message = Message.builder()
+                .userId(request.getSenderId())
+                .chatRoomId(chatRoomId)
+                .chatParticipation(participation)
+                .messageContents(request.getMessageContents())
+                .messageType(request.getFile() != null ? MessageType.FILE : MessageType.TEXT)
+//                .fileName(request.getFile() != null ? request.getFile().getOriginalFilename() : null)
+//                .fileSize(request.getFile() != null ? String.valueOf(request.getFile().getSize()) : null)
+//                .fileType(request.getFile() != null ? request.getFile().getContentType() : null)
+//                .fileUrl(request.getFile() != null ? "/files/" + request.getFile().getOriginalFilename() : null)
+                .build();
+
+        messageRepository.save(message);
+
+        // Kafka 로 메시지 전송
+        String topic = "chat-room-" + chatRoomId.toString();
+        try {
+            String messageStr = objectMapper.writeValueAsString(request);
+            kafkaTemplate.send(topic, request.getSenderId().toString(), messageStr);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace(); // 예외 처리
+        }
+
+        List<Long> participantIds = chatParticipationRepository.findById(chatRoomId).stream()
+                .map(chatParticipation -> chatParticipation.getUser().getUserId())
+                .collect(Collectors.toList());
+
+        return MessageResponse.builder()
+                .chatRoomName(message.getChatParticipation().getChatRoom().getChatRoomName())
+                .participants(participantIds)
+                .topicName(topic)
+                .fileType(message.getFileType())
+                .fileSize(message.getFileSize())
+                .fileName(message.getFileName())
+                .fileUrl(message.getFileUrl())
+                .messageContents(message.getMessageContents())
+                .messageType(message.getMessageType())
+                .build();
+    }
+
+    @KafkaListener(topicPattern = "chat-room-.*", groupId = "${spring.kafka.consumer.group-id}")
+    public void consumeMessage(ConsumerRecord<String, String> record) {
+        try {
+            MessageRequest request = objectMapper.readValue(record.value(), MessageRequest.class);
+            // STOMP 를 통해 웹소켓으로 메시지 전송
+            messagingTemplate.convertAndSend("/sub/room/" + request.getChatRoomId().toString(), request);
+        } catch (IOException e) {
+            e.printStackTrace(); // 예외 처리
+        }
+    }
+}

--- a/backend/src/main/java/minionz/backend/chat/message/model/Message.java
+++ b/backend/src/main/java/minionz/backend/chat/message/model/Message.java
@@ -3,6 +3,7 @@ package minionz.backend.chat.message.model;
 import jakarta.persistence.*;
 import lombok.*;
 import minionz.backend.chat.chat_participation.model.ChatParticipation;
+import minionz.backend.common.BaseEntity;
 
 import java.time.LocalDateTime;
 
@@ -12,7 +13,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 @Entity
-public class Message {
+public class Message extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long messageId;
@@ -20,18 +21,22 @@ public class Message {
     private Long chatRoomId;
     private Long userId;
 
-    private String content;
+    private String messageContents;
     private String fileType;
     private String fileSize;
     private String fileUrl;
     private String fileName;
     private LocalDateTime deletedAt;
+
+    @Enumerated(EnumType.STRING)
     private MessageType messageType;
+
+    @Enumerated(EnumType.STRING)
     private MessageStatus messageStatus;
 
     // ChatParticipation N : 1
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "chatParticipation_id")
+    @JoinColumn(name = "chat_participation_id")
     private ChatParticipation chatParticipation;
 
 }

--- a/backend/src/main/java/minionz/backend/chat/message/model/request/MessageRequest.java
+++ b/backend/src/main/java/minionz/backend/chat/message/model/request/MessageRequest.java
@@ -1,20 +1,14 @@
 package minionz.backend.chat.message.model.request;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import org.springframework.web.multipart.MultipartFile;
+import lombok.*;
 
 @Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
+@Builder(toBuilder = true)
 public class MessageRequest {
 
-    private Long senderId;
-    private Long chatroomId;
     private String messageContents;
-    private MultipartFile file;
-
+//    private MultipartFile file;
+    private String  file;
+    private Long chatRoomId;
+    private Long senderId;
 }

--- a/backend/src/main/java/minionz/backend/chat/message/model/request/PrivateMessageRequest.java
+++ b/backend/src/main/java/minionz/backend/chat/message/model/request/PrivateMessageRequest.java
@@ -1,0 +1,15 @@
+package minionz.backend.chat.message.model.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(toBuilder = true)
+public class PrivateMessageRequest {
+    private String messageContents;
+    //    private MultipartFile file;
+    private String  file;
+    private Long chatRoomId;
+    private Long senderId;
+    private Long receiverId;
+}

--- a/backend/src/main/java/minionz/backend/chat/message/model/response/MessageResponse.java
+++ b/backend/src/main/java/minionz/backend/chat/message/model/response/MessageResponse.java
@@ -2,13 +2,13 @@ package minionz.backend.chat.message.model.response;
 
 import lombok.Builder;
 import lombok.Getter;
-import minionz.backend.common.BaseEntity;
+import minionz.backend.chat.message.model.MessageType;
 
 import java.util.List;
 
 @Builder
 @Getter
-public class MessageResponse extends BaseEntity {
+public class MessageResponse {
     private String chatRoomName;
     private List<Long> participants;
     private String topicName;
@@ -16,5 +16,6 @@ public class MessageResponse extends BaseEntity {
     private String fileSize;
     private String fileName;
     private String fileUrl;
-
+    private String messageContents;
+    private MessageType messageType;
 }

--- a/backend/src/main/java/minionz/backend/chat/message/model/response/PrivateMessageResponse.java
+++ b/backend/src/main/java/minionz/backend/chat/message/model/response/PrivateMessageResponse.java
@@ -1,0 +1,21 @@
+package minionz.backend.chat.message.model.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import minionz.backend.chat.message.model.MessageType;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class PrivateMessageResponse {
+    private String chatRoomName;
+    private List<Long> participants;
+    private String topicName;
+    private String fileType;
+    private String fileSize;
+    private String fileName;
+    private String fileUrl;
+    private String messageContents;
+    private MessageType messageType;
+}

--- a/backend/src/main/java/minionz/backend/common/responses/BaseResponseStatus.java
+++ b/backend/src/main/java/minionz/backend/common/responses/BaseResponseStatus.java
@@ -52,12 +52,19 @@ public enum BaseResponseStatus {
     ERRORBOARD_CREATE_SUCCESS(true, 5001, "게시판 등록에 성공했습니다."),
     ERRORBOARD_SEARCH_SUCCESS(true, 5101, "게시판 검색에 성공했습니다."),
     ERRORBOARD_SERACH_FAIL(true, 5102, "게시판 검색에 성공했습니다."),
-    ERRORCOMMENT_CREATE_SUCCESS(true, 5201, "댓글 등록에 성공했습니다.");
+    ERRORCOMMENT_CREATE_SUCCESS(true, 5201, "댓글 등록에 성공했습니다."),
 
 
     /**
      * 6000: 채팅
      */
+
+    CHATROOM_CREATE_SUCCESS(true, 6001, "채팅방 생성에 성공했습니다."),
+    CHATROOM_CREATE_FAIL(false, 6002, "채팅방 생성에 실패했습니다."),
+    CHATROOM_LIST_SUCCESS(true, 6101, "채팅방 조회에 성공했습니다."),
+    CHATROOM_LIST_FAIL(false, 6102, "채팅방 조회에 실패했습니다."),
+    MESSAGE_SEND_SUCCESS(true, 6201, "메세지가 성공적으로 전송되었습니다."),
+    MESSAGE_SEND_FAIL(false, 6202, "메세지가 전송되지 않았습니다.");
 
 
     /**

--- a/backend/src/main/java/minionz/backend/config/kafka/KafkaConstants.java
+++ b/backend/src/main/java/minionz/backend/config/kafka/KafkaConstants.java
@@ -1,7 +1,0 @@
-package minionz.backend.config.kafka;
-
-import java.util.UUID;
-
-public class KafkaConstants {
-    public static final String GROUP_ID = UUID.randomUUID().toString();
-}

--- a/backend/src/main/java/minionz/backend/config/kafka/KafkaConsumerConfig.java
+++ b/backend/src/main/java/minionz/backend/config/kafka/KafkaConsumerConfig.java
@@ -1,6 +1,5 @@
 package minionz.backend.config.kafka;
 
-import minionz.backend.chat.message.model.request.MessageRequest;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.beans.factory.annotation.Value;
@@ -10,7 +9,6 @@ import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
-import org.springframework.kafka.support.serializer.JsonDeserializer;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -23,39 +21,24 @@ public class KafkaConsumerConfig {
     private String kafkaBroker;
 
     @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, MessageRequest> kafkaListenerContainerFactory() {
-        // 카프카에서 비동기적으로 메세지를 수신하는 리스너 컨테이너를 생성.
-        // 아래에서 생성 된 consumerFactory 를 설정한다.
-        ConcurrentKafkaListenerContainerFactory<String, MessageRequest> factory = new ConcurrentKafkaListenerContainerFactory<>();
-        factory.setConsumerFactory(consumerFactory());
-        // consumerFactory 를 설정하는 곳 -> 나중에 수신하는 메소드가 있는 곳으로 간다.
-        return factory;
+    public ConsumerFactory<String, String> stringConsumerFactory() {
+        return new DefaultKafkaConsumerFactory<>(stringConsumerConfig());
     }
 
     @Bean
-    public ConsumerFactory<String, MessageRequest> consumerFactory() {
-        // kafka 에서 메세지를 가져오는 역할을 한다 -> string 타입의 키와 MessageRequest 타입의 값을 가진
-        // 메세지를 처리할 수 있는 consumerFactory 를 생성.
-        return new DefaultKafkaConsumerFactory<>(consumerConfigurations(), new StringDeserializer(), new JsonDeserializer<>(MessageRequest.class));
-    }
-
-    @Bean
-    public Map<String, Object> consumerConfigurations() {
+    public Map<String, Object> stringConsumerConfig() {
         Map<String, Object> config = new HashMap<>();
-        // hashmap 을 통해서 빈 설정 맵을 만들어서 kafka 에 필요한 설정들을 put 하기.
-
-        JsonDeserializer<MessageRequest> deserializer = new JsonDeserializer<>(MessageRequest.class);
-        deserializer.setRemoveTypeHeaders(false);
-        deserializer.addTrustedPackages("*");
-        deserializer.setUseTypeMapperForKey(true);
-
         config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaBroker);
         config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, deserializer);
-        config.put(ConsumerConfig.GROUP_ID_CONFIG, KafkaConstants.GROUP_ID);
+        config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
-
         return config;
     }
-}
 
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> stringKafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(stringConsumerFactory());
+        return factory;
+    }
+}

--- a/backend/src/main/java/minionz/backend/config/kafka/KafkaProducerConfig.java
+++ b/backend/src/main/java/minionz/backend/config/kafka/KafkaProducerConfig.java
@@ -1,48 +1,39 @@
 package minionz.backend.config.kafka;
 
-import minionz.backend.chat.message.model.request.MessageRequest;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.kafka.annotation.EnableKafka;
-import org.apache.kafka.common.serialization.StringSerializer;
-import org.springframework.kafka.core.ProducerFactory;
-import org.springframework.kafka.support.serializer.JsonSerializer;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
 
-@EnableKafka
 @Configuration
 public class KafkaProducerConfig {
-    // ProducerFactory 와 KafkaTemplate 을 설정하여 Kafka 에 메시지를 전송할 준비
 
     @Value("${spring.kafka.producer.bootstrap-servers}")
     private String kafkaBroker;
 
     @Bean
-    // 2) 아래에서 구성한대로 Kafka Producer 를 생성해서 3으로 준다
-    public ProducerFactory<String, MessageRequest> producerFactory() {
-        return new DefaultKafkaProducerFactory<>(kafkaProducerConfiguration());
+    public ProducerFactory<String, String> stringProducerFactory() {
+        return new DefaultKafkaProducerFactory<>(stringProducerConfig());
     }
 
     @Bean
-    // 1) Kafka 프로듀서에 필요한 설정들을 HashMap 으로 정의해서 put 으로 추가해서 2로 전달
-    public Map<String, Object> kafkaProducerConfiguration() {
+    public Map<String, Object> stringProducerConfig() {
         Map<String, Object> config = new HashMap<>();
         config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaBroker);
         config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         return config;
     }
 
     @Bean
-    // 3) producerFactory 를 사용하여 생성한 것을 kafka 토픽을 통해 메세지를 전송
-    public KafkaTemplate<String, MessageRequest> kafkaTemplate() {
-        return new KafkaTemplate<>(producerFactory());
+    public KafkaTemplate<String, String> stringKafkaTemplate() {
+        return new KafkaTemplate<>(stringProducerFactory());
     }
 }
-


### PR DESCRIPTION
## 연관된 이슈
 [#2, #11, #20] 
<br>

## 작업 내용
- Build 부분에 json 데이터를 처리하기 위해 jackson 추가 했습니다. 
- baseResponse에 채팅 관련 상태 6000번으로 추가 했습니다.
- 채팅, 채팅방, 채팅참여 관련 엔티티 속성 추가 했습니다.
- kafka 그룹id를 원래 uuid로 설정되게 받아 왔었는데 kafka consumerconfig가 제대로 읽히지 않는 오류로 그룹 id를 지정하는 형태로 변경 했습니다. 이 부분은 전달사항 참고 하시면 추가적으로 적어두겠습니다. 
  - <String, MessageRequst> 형태와 , <String, String> 형태 두 가지 형태로 받아왔었는데 producerConfig와, ConsumerConfig 둘 다 팩토리 생성에서 문제가 생기는 것 같아 <String, MessageRequst> 로 받아오는 형식을 아예 삭제 했습니다.
- kafka 메세지 전송 및 토픽에 메세지 내용이 저장 되는 것을 확인했습니다. 현재 그룹 채팅까지 구현했고, 개인 채팅은 이후에 구현 예정입니다.
<br> 

## 전달 사항
application.yml에 그룹 아이디를 지정 해 주시면 됩니다. 지정 관련은 discord에 올려두도록 하겠습니다. 현재 kafka 메세지 보낼 때 파일 형식은 주석 처리 했습니다. 이는 s3를 통해서 링크를 받아오는 형식으로 수정 예정입니다.
