### PR TITLE
[Feat] SPRINT_005, TASK_005 - 스프린트 및 태스크 상태 변경 기능 구현 [#100, #90]

### DIFF
--- a/backend/src/main/java/minionz/backend/common/responses/BaseResponseStatus.java
+++ b/backend/src/main/java/minionz/backend/common/responses/BaseResponseStatus.java
@@ -41,6 +41,7 @@ public enum BaseResponseStatus {
     MEETING_READ_SUCCESS(true, 4013, "회의 상세 조회에 성공했습니다."),
     ISSUE_CREATE_SUCCESS(true, 4014, "이슈 생성에 성공했습니다."),
     TASK_STATUS_UPDATE_SUCCESS(true, 4015, "태스크 상태 변경에 성공했습니다."),
+    SPRINT_STATUS_UPDATE_SUCCESS(true, 4016, "스프린트 상태 변경에 성공했습니다."),
 
 
     WORKSPACE_ACCESS_DENIED(false, 4101, "워크스페이스에 접근 권한이 없습니다."),

--- a/backend/src/main/java/minionz/backend/common/responses/BaseResponseStatus.java
+++ b/backend/src/main/java/minionz/backend/common/responses/BaseResponseStatus.java
@@ -40,6 +40,7 @@ public enum BaseResponseStatus {
     MEETING_CREATE_SUCCESS(true, 4012, "회의 생성에 성공했습니다."),
     MEETING_READ_SUCCESS(true, 4013, "회의 상세 조회에 성공했습니다."),
     ISSUE_CREATE_SUCCESS(true, 4014, "이슈 생성에 성공했습니다."),
+    TASK_STATUS_UPDATE_SUCCESS(true, 4015, "태스크 상태 변경에 성공했습니다."),
 
 
     WORKSPACE_ACCESS_DENIED(false, 4101, "워크스페이스에 접근 권한이 없습니다."),
@@ -48,6 +49,7 @@ public enum BaseResponseStatus {
     TASK_LABEL_SELECT_FAIL(false, 4104, "담당자를 지정할 권한이 존재하지 않습니다."),
     TASK_NOT_EXISTS(false, 4105, "존재하지 않는 태스크입니다."),
     MEETING_NOT_EXISTS(false, 4106, "존재하지 않는 회의 일정입니다."),
+    UNCHANGED(false, 4107, "이전과 동일한 상태입니다."),
 
 
 

--- a/backend/src/main/java/minionz/backend/scrum/sprint/SprintController.java
+++ b/backend/src/main/java/minionz/backend/scrum/sprint/SprintController.java
@@ -5,6 +5,7 @@ import minionz.backend.common.exception.BaseException;
 import minionz.backend.common.responses.BaseResponse;
 import minionz.backend.common.responses.BaseResponseStatus;
 import minionz.backend.scrum.sprint.model.request.CreateSprintRequest;
+import minionz.backend.scrum.sprint.model.request.UpdateSprintStatusRequest;
 import minionz.backend.scrum.sprint.model.response.ReadAllSprintResponse;
 import minionz.backend.scrum.sprint.model.response.ReadSprintResponse;
 import minionz.backend.user.model.User;
@@ -59,4 +60,19 @@ public class SprintController {
 
         return new BaseResponse<>(BaseResponseStatus.SPRINT_READ_ALL_SUCCESS, response);
     }
+
+    @PatchMapping("/{sprintId}")
+    public BaseResponse<BaseResponseStatus> updateSprintStatus(@PathVariable Long sprintId, @RequestBody UpdateSprintStatusRequest request) {
+        User user = User.builder().userId(1L).build();
+
+        try {
+            sprintService.updateSprintStatus(sprintId, request);
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+
+        return new BaseResponse<>(BaseResponseStatus.SPRINT_STATUS_UPDATE_SUCCESS);
+    }
+
+
 }

--- a/backend/src/main/java/minionz/backend/scrum/sprint/model/request/UpdateSprintStatusRequest.java
+++ b/backend/src/main/java/minionz/backend/scrum/sprint/model/request/UpdateSprintStatusRequest.java
@@ -1,0 +1,9 @@
+package minionz.backend.scrum.sprint.model.request;
+
+import lombok.Getter;
+import minionz.backend.scrum.sprint.model.SprintStatus;
+
+@Getter
+public class UpdateSprintStatusRequest {
+    private SprintStatus status;
+}

--- a/backend/src/main/java/minionz/backend/scrum/task/TaskController.java
+++ b/backend/src/main/java/minionz/backend/scrum/task/TaskController.java
@@ -5,6 +5,7 @@ import minionz.backend.common.exception.BaseException;
 import minionz.backend.common.responses.BaseResponse;
 import minionz.backend.common.responses.BaseResponseStatus;
 import minionz.backend.scrum.task.model.request.CreateTaskRequest;
+import minionz.backend.scrum.task.model.request.UpdateTaskStatusRequest;
 import minionz.backend.scrum.task.model.response.ReadAllTaskResponse;
 import minionz.backend.scrum.task.model.response.ReadTaskResponse;
 import minionz.backend.user.model.User;
@@ -58,6 +59,19 @@ public class TaskController {
         }
 
         return new BaseResponse<>(BaseResponseStatus.TASK_READ_ALL_SUCCESS, response);
+    }
+
+    @PatchMapping("/{taskId}")
+    public BaseResponse<BaseResponseStatus> updateTaskStatus(@PathVariable Long taskId, @RequestBody UpdateTaskStatusRequest request) {
+        User user = User.builder().userId(1L).build();
+
+        try {
+            taskService.updateTaskStatus(taskId, request);
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+
+        return new BaseResponse<>(BaseResponseStatus.TASK_STATUS_UPDATE_SUCCESS);
     }
 
 

--- a/backend/src/main/java/minionz/backend/scrum/task/TaskService.java
+++ b/backend/src/main/java/minionz/backend/scrum/task/TaskService.java
@@ -15,6 +15,7 @@ import minionz.backend.scrum.sprint_participation.model.SprintParticipation;
 import minionz.backend.scrum.task.model.Task;
 import minionz.backend.scrum.task.model.TaskStatus;
 import minionz.backend.scrum.task.model.request.CreateTaskRequest;
+import minionz.backend.scrum.task.model.request.UpdateTaskStatusRequest;
 import minionz.backend.scrum.task.model.response.ReadAllTaskResponse;
 import minionz.backend.scrum.task.model.response.ReadTaskResponse;
 import minionz.backend.scrum.task_participation.TaskParticipationRepository;
@@ -23,6 +24,7 @@ import minionz.backend.user.model.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -137,6 +139,39 @@ public class TaskService {
         ).toList();
 
         return response;
+    }
+
+    public void updateTaskStatus(Long taskId, UpdateTaskStatusRequest request) throws BaseException {
+        Optional<Task> result = taskRepository.findById(taskId);
+
+        if(result.isEmpty()){
+            throw new BaseException(BaseResponseStatus.INVALID_ACCESS);
+        }
+
+        Task task = result.get();
+
+        if(task.getStatus() == request.getStatus()){
+            throw new BaseException(BaseResponseStatus.UNCHANGED);
+        }
+
+
+        taskRepository.save(
+                Task
+                        .builder()
+                        .taskId(task.getTaskId())
+                        .taskTitle(task.taskTitle)
+                        .taskContents(task.getTaskContents())
+                        .startDate(task.getStartDate())
+                        .endDate(task.getEndDate())
+                        .doneDate(request.getStatus() == TaskStatus.DONE ? LocalDateTime.now() : null)
+                        .difficultly(task.getDifficultly())
+                        .priority(task.getPriority())
+                        .status(request.getStatus())
+                        .taskNumber(task.getTaskNumber())
+                        .sprint(task.getSprint())
+                        .meeting(task.getMeeting())
+                        .build()
+        );
     }
 
     public List<Label> findLabels(Task task) {

--- a/backend/src/main/java/minionz/backend/scrum/task/model/request/UpdateTaskStatusRequest.java
+++ b/backend/src/main/java/minionz/backend/scrum/task/model/request/UpdateTaskStatusRequest.java
@@ -1,6 +1,5 @@
 package minionz.backend.scrum.task.model.request;
 
-import lombok.Builder;
 import lombok.Getter;
 import minionz.backend.scrum.task.model.TaskStatus;
 

--- a/backend/src/main/java/minionz/backend/scrum/task/model/request/UpdateTaskStatusRequest.java
+++ b/backend/src/main/java/minionz/backend/scrum/task/model/request/UpdateTaskStatusRequest.java
@@ -1,0 +1,11 @@
+package minionz.backend.scrum.task.model.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import minionz.backend.scrum.task.model.TaskStatus;
+
+
+@Getter
+public class UpdateTaskStatusRequest {
+    private TaskStatus status;
+}


### PR DESCRIPTION
## 연관된 이슈
#100 , #90 
<br>

## 작업 내용
- 태스크 상태 변경 기능을 구현했습니다.
- 스프린트 상태 변경 기능을 구현했습니다.
- 존재하지 않은 스프린트 및 태스크의 상태를 변경하려고 할 때는 예외처리 했습니다.
- 이전 상태와 동일한 상태로 변경할 때는 예외처리를 했습니다.
- 상태를 DONE으로 변경하면, done_date에 현재 시간이 들어가도록 구현했습니다.
- DONE에서 DONE이 아닌 상태로 변경되면, done_date는 삭제되도록 구현했습니다.
- 스프린트 상태를 DONE으로 변경하면, 스프린트에 속해있는 모든 태스크의 상태를 DONE으로 변경하도록 구현했습니다.
<br> 

## 전달 사항

close #90 
close #100 