### PR TITLE
[Feat] CHAT_005,011 - 메세지 및 파일 전송 구현 [#20,#150]

### DIFF
--- a/backend/src/main/java/minionz/backend/chat/message/MessageController.java
+++ b/backend/src/main/java/minionz/backend/chat/message/MessageController.java
@@ -7,10 +7,8 @@ import minionz.backend.common.responses.BaseResponse;
 import minionz.backend.common.responses.BaseResponseStatus;
 import minionz.backend.user.model.CustomSecurityUserDetails;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/message")
@@ -23,8 +21,21 @@ public class MessageController {
     @PostMapping("/send")
     public BaseResponse<MessageResponse> sendMessage(@RequestBody MessageRequest request, @AuthenticationPrincipal CustomSecurityUserDetails userDetails) {
         Long senderId = userDetails.getUser().getUserId();
-        System.out.println("Sender ID: " + senderId);
-        MessageResponse response = messageService.sendMessage(request.getChatRoomId(), request, senderId);
+        MessageResponse response = messageService.sendMessage(request.getChatRoomId(), request,null, senderId);
+        return new BaseResponse<>(BaseResponseStatus.MESSAGE_SEND_SUCCESS, response);
+    }
+
+    @PostMapping("/sendFile")
+    public BaseResponse<MessageResponse> sendFile(
+            @RequestParam("chatRoomId") Long chatRoomId,
+            @RequestPart(name = "files") MultipartFile[] files,
+            @AuthenticationPrincipal CustomSecurityUserDetails userDetails) {
+
+        Long senderId = userDetails.getUser().getUserId();
+        MessageRequest request = new MessageRequest();
+        request.setChatRoomId(chatRoomId);
+        // files 전달
+        MessageResponse response = messageService.sendMessage(chatRoomId, request, files, senderId);
 
         return new BaseResponse<>(BaseResponseStatus.MESSAGE_SEND_SUCCESS, response);
     }

--- a/backend/src/main/java/minionz/backend/chat/message/model/request/MessageRequest.java
+++ b/backend/src/main/java/minionz/backend/chat/message/model/request/MessageRequest.java
@@ -2,12 +2,17 @@ package minionz.backend.chat.message.model.request;
 
 import lombok.*;
 
+import java.util.List;
+
 @Getter
 @Builder(toBuilder = true)
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class MessageRequest {
 
     private String messageContents;
 //    private MultipartFile file;
-    private String  file;
+    private List<String> files;
     private Long chatRoomId;
 }


### PR DESCRIPTION
## 연관된 이슈
 #20,#150
<br>

## 작업 내용
- 전에는 메세지를 전송하고 파일 형식을 남겨둔 채 구현을 했었습니다.
  - 파일을 받는 /sendFile api를 따로 구현하고, service는 일반 메세지를 받는 것과 병합했습니다.
  - 파일을 받았을 때 kafka로 전송하게 되면 바이너리형식으로 변환해서 쪼개서 관리하는 것 때문에 비효율적이라고 판단 했습니다.
  - s3에 저장해서 url을 response로 전달해주는 식으로 구현 했습니다.
<br> 

## 전달 사항
close #150 
close #20 
