### PR TITLE
[Feat] KANBAN_001, KANBAN_002 - 칸반 조회 기능 구현 [#102, #104]

### DIFF
--- a/backend/src/main/java/minionz/backend/scrum/task/TaskController.java
+++ b/backend/src/main/java/minionz/backend/scrum/task/TaskController.java
@@ -61,6 +61,20 @@ public class TaskController {
         return new BaseResponse<>(BaseResponseStatus.TASK_READ_ALL_SUCCESS, response);
     }
 
+    @GetMapping("/all/my")
+    public BaseResponse<List<ReadAllTaskResponse>> readAllMyTask() {
+        User user = User.builder().userId(1L).build();
+        List<ReadAllTaskResponse> response;
+
+        try {
+            response = taskService.readAllMyTask(user);
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+
+        return new BaseResponse<>(BaseResponseStatus.TASK_READ_ALL_SUCCESS, response);
+    }
+
     @PatchMapping("/{taskId}")
     public BaseResponse<BaseResponseStatus> updateTaskStatus(@PathVariable Long taskId, @RequestBody UpdateTaskStatusRequest request) {
         User user = User.builder().userId(1L).build();

--- a/backend/src/main/java/minionz/backend/scrum/task/TaskRepository.java
+++ b/backend/src/main/java/minionz/backend/scrum/task/TaskRepository.java
@@ -17,7 +17,7 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
    @Query("SELECT t FROM Task t " +
            "JOIN FETCH TaskParticipation tp ON t = tp.task " +
            "JOIN FETCH Sprint s ON t.sprint = s " +
-           "WHERE tp.user.userId = :userId AND s.endDate < CURRENT_TIMESTAMP")
+           "WHERE tp.user.userId = :userId AND s.endDate > CURRENT_TIMESTAMP")
    List<Task> findMyTask(Long userId);
 }
 

--- a/backend/src/main/java/minionz/backend/scrum/task/TaskRepository.java
+++ b/backend/src/main/java/minionz/backend/scrum/task/TaskRepository.java
@@ -8,9 +8,17 @@ import java.util.List;
 
 public interface TaskRepository extends JpaRepository<Task, Long> {
    @Query("SELECT COUNT(*) AS task_count " +
-   "FROM Task t " +
-    "WHERE t.sprint.sprintId = :sprintId")
+           "FROM Task t " +
+           "WHERE t.sprint.sprintId = :sprintId")
     int findTaskCount(Long sprintId);
 
    List<Task> findAllBySprintSprintId(Long sprintId);
+
+   @Query("SELECT t FROM Task t " +
+           "JOIN FETCH Sprint s ON t.sprint = s " +
+           "JOIN FETCH SprintParticipation sp ON s = sp.sprint " +
+           "WHERE sp.user.userId = :userId AND s.endDate < CURRENT_TIMESTAMP")
+   List<Task> findMyTask(Long userId);
 }
+
+

--- a/backend/src/main/java/minionz/backend/scrum/task/TaskRepository.java
+++ b/backend/src/main/java/minionz/backend/scrum/task/TaskRepository.java
@@ -15,9 +15,9 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
    List<Task> findAllBySprintSprintId(Long sprintId);
 
    @Query("SELECT t FROM Task t " +
+           "JOIN FETCH TaskParticipation tp ON t = tp.task " +
            "JOIN FETCH Sprint s ON t.sprint = s " +
-           "JOIN FETCH SprintParticipation sp ON s = sp.sprint " +
-           "WHERE sp.user.userId = :userId AND s.endDate < CURRENT_TIMESTAMP")
+           "WHERE tp.user.userId = :userId AND s.endDate < CURRENT_TIMESTAMP")
    List<Task> findMyTask(Long userId);
 }
 

--- a/backend/src/main/java/minionz/backend/scrum/task/TaskService.java
+++ b/backend/src/main/java/minionz/backend/scrum/task/TaskService.java
@@ -7,6 +7,7 @@ import minionz.backend.scrum.label.model.TaskLabel;
 import minionz.backend.scrum.label_select.TaskLabelSelectRepository;
 import minionz.backend.scrum.label_select.model.TaskLabelSelect;
 import minionz.backend.scrum.meeting.model.Meeting;
+import minionz.backend.scrum.sprint.SprintRepository;
 import minionz.backend.scrum.sprint.model.Sprint;
 import minionz.backend.scrum.sprint.model.response.Label;
 import minionz.backend.scrum.sprint.model.response.Participant;
@@ -20,6 +21,8 @@ import minionz.backend.scrum.task.model.response.ReadAllTaskResponse;
 import minionz.backend.scrum.task.model.response.ReadTaskResponse;
 import minionz.backend.scrum.task_participation.TaskParticipationRepository;
 import minionz.backend.scrum.task_participation.model.TaskParticipation;
+import minionz.backend.scrum.workspace.WorkspaceRepository;
+import minionz.backend.scrum.workspace.model.Workspace;
 import minionz.backend.user.model.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +38,7 @@ public class TaskService {
     private final TaskLabelSelectRepository taskLabelSelectRepository;
     private final SprintParticipationRepository sprintParticipationRepository;
     private final TaskParticipationRepository taskParticipationRepository;
+    private final SprintRepository sprintRepository;
 
     @Transactional
     public void createTask(User user, CreateTaskRequest request) {
@@ -112,9 +116,11 @@ public class TaskService {
     }
 
 
-
     public List<ReadAllTaskResponse> readAllTask(Long sprintId) {
         List<Task> result = taskRepository.findAllBySprintSprintId(sprintId);
+
+        Optional<Sprint> sprint = sprintRepository.findById(sprintId);
+        String workspaceName = sprint.get().getWorkspace().getWorkspaceName();
 
         List<ReadAllTaskResponse> response = result.stream().map(
                 task -> ReadAllTaskResponse
@@ -128,22 +134,47 @@ public class TaskService {
                         .taskNumber(task.getTaskNumber())
                         .participants(findParticipants(task))
                         .priority(task.getPriority())
+                        .workspaceName(workspaceName)
                         .build()
         ).toList();
 
         return response;
     }
 
+    public List<ReadAllTaskResponse> readAllMyTask(User user) {
+
+        List<Task> result = taskRepository.findMyTask(user.getUserId());
+
+        List<ReadAllTaskResponse> response = result.stream().map(
+                task -> ReadAllTaskResponse
+                        .builder()
+                        .id(task.getTaskId())
+                        .status(task.getStatus())
+                        .title(task.getTaskTitle())
+                        .labels(findLabels(task))
+                        .startDate(task.getStartDate())
+                        .endDate(task.getEndDate())
+                        .taskNumber(task.getTaskNumber())
+                        .participants(findParticipants(task))
+                        .priority(task.getPriority())
+                        .workspaceName(task.getSprint().getWorkspace().getWorkspaceName())
+                        .build()
+        ).toList();
+
+        return response;
+    }
+
+
     public void updateTaskStatus(Long taskId, UpdateTaskStatusRequest request) throws BaseException {
         Optional<Task> result = taskRepository.findById(taskId);
 
-        if(result.isEmpty()){
+        if (result.isEmpty()) {
             throw new BaseException(BaseResponseStatus.INVALID_ACCESS);
         }
 
         Task task = result.get();
 
-        if(task.getStatus() == request.getStatus()){
+        if (task.getStatus() == request.getStatus()) {
             throw new BaseException(BaseResponseStatus.UNCHANGED);
         }
 
@@ -187,7 +218,6 @@ public class TaskService {
                         .build()
         ).toList();
     }
-
 
 
 }

--- a/backend/src/main/java/minionz/backend/scrum/task/TaskService.java
+++ b/backend/src/main/java/minionz/backend/scrum/task/TaskService.java
@@ -112,15 +112,6 @@ public class TaskService {
     }
 
 
-    public List<Participant> findParticipants(Task task) {
-        return task.getTaskParticipations().stream().map(
-                participant -> Participant.builder()
-                        .id(participant.getUser().getUserId())
-                        .userName(participant.getUser().getUserName())
-                        .isManager(true)
-                        .build()
-        ).toList();
-    }
 
     public List<ReadAllTaskResponse> readAllTask(Long sprintId) {
         List<Task> result = taskRepository.findAllBySprintSprintId(sprintId);
@@ -135,6 +126,8 @@ public class TaskService {
                         .startDate(task.getStartDate())
                         .endDate(task.getEndDate())
                         .taskNumber(task.getTaskNumber())
+                        .participants(findParticipants(task))
+                        .priority(task.getPriority())
                         .build()
         ).toList();
 
@@ -184,6 +177,17 @@ public class TaskService {
                         .build()
         ).toList();
     }
+
+    public List<Participant> findParticipants(Task task) {
+        return task.getTaskParticipations().stream().map(
+                participant -> Participant.builder()
+                        .id(participant.getUser().getUserId())
+                        .userName(participant.getUser().getUserName())
+                        .isManager(true)
+                        .build()
+        ).toList();
+    }
+
 
 
 }

--- a/backend/src/main/java/minionz/backend/scrum/task/model/response/ReadAllTaskResponse.java
+++ b/backend/src/main/java/minionz/backend/scrum/task/model/response/ReadAllTaskResponse.java
@@ -3,6 +3,8 @@ package minionz.backend.scrum.task.model.response;
 import lombok.Builder;
 import lombok.Getter;
 import minionz.backend.scrum.sprint.model.response.Label;
+import minionz.backend.scrum.sprint.model.response.Participant;
+import minionz.backend.scrum.task.model.TaskLevel;
 import minionz.backend.scrum.task.model.TaskStatus;
 
 import java.time.LocalDateTime;
@@ -15,7 +17,9 @@ public class ReadAllTaskResponse {
     private String title;
     private TaskStatus status;
     private List<Label> labels;
+    private String taskNumber;
     private LocalDateTime startDate;
     private LocalDateTime endDate;
-    private String taskNumber;
+    private List<Participant> participants;
+    private TaskLevel priority;
 }

--- a/backend/src/main/java/minionz/backend/scrum/task/model/response/ReadAllTaskResponse.java
+++ b/backend/src/main/java/minionz/backend/scrum/task/model/response/ReadAllTaskResponse.java
@@ -22,4 +22,5 @@ public class ReadAllTaskResponse {
     private LocalDateTime endDate;
     private List<Participant> participants;
     private TaskLevel priority;
+    private String workspaceName;
 }

--- a/backend/src/main/java/minionz/backend/scrum/workspace/WorkspaceController.java
+++ b/backend/src/main/java/minionz/backend/scrum/workspace/WorkspaceController.java
@@ -30,7 +30,7 @@ public class WorkspaceController {
     @GetMapping("/all")
     public BaseResponse<List<ReadWorkspaceResponse>> readAllWorkspace() {
 //      TODO: 추 후 AuthenticationPrincipal로 user 찾도록 수정.
-        User user = User.builder().userId(2L).build();
+        User user = User.builder().userId(1L).build();
 
         List<ReadWorkspaceResponse> readWorkspaceResponses = workspaceService.readAll(user);
 


### PR DESCRIPTION
## 연관된 이슈
#102 , #104 
<br>

## 작업 내용
- 워크스페이스 내의 스프린트 별 칸반조회 기능을 구현했습니다.
- 로그인 한 유저의 모든 워크스페이스에 대한 칸반조회 기능을 구현했습니다.
- 나의 칸반에서는, 스프린트의 마감일이 현재 시점보다 이후인 스프린트에 대해서만 태스크를 조회하도록 구현했습니다.
- 이전에 구현했던 스프린트 리스트 목록 조회 기능을 수정하여 워크스페이스 칸반 조회와 함께 사용할 수 있도록 수정했습니다.
<br> 

## 전달 사항

close #102 
close #104 
