### PR TITLE
[Fix] CHAT_001,005,006 - 채팅방에 본인 id 추가 [#2,#20,#22]

### DIFF
--- a/backend/src/main/java/minionz/backend/chat/chat_room/ChatRoomService.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_room/ChatRoomService.java
@@ -34,9 +34,14 @@ public class ChatRoomService {
     private final UserRepository userRepository;
 
     public BaseResponse<CreateChatRoomResponse> create(User user, CreateChatRoomRequest request) {
-        String chatRoomName;
+        // 로그인한 사용자가 채팅 참여에 포함되지 않았을시에 추가
+        if (!request.getParticipants().contains(user.getUserId())) {
+            request.getParticipants().add(user.getUserId());
+        }
 
-        if (request.getParticipants().size() == 1) {
+        String chatRoomName;
+        // 본인을 추가해서 총 2명일 경우
+        if (request.getParticipants().size() == 2) {
             // 개인 채팅의 경우 상대방의 이름으로 설정
             User participant = userRepository.findById(request.getParticipants().get(0))
                     .orElse(null);
@@ -60,7 +65,7 @@ public class ChatRoomService {
 
         // Kafka 토픽과 메시지 전송
         createKafkaTopic(chatRoomIdStr);
-        sendCreationMessage(chatRoomIdStr, "채팅방이 생성되었습니다.");
+//        sendCreationMessage(chatRoomIdStr, "채팅방이 생성되었습니다.");
 
         CreateChatRoomResponse chatRoomResponse = buildCreateChatRoomResponse(chatRoom, request.getParticipants(), chatRoomIdStr);
         return new BaseResponse<>(BaseResponseStatus.CHATROOM_CREATE_SUCCESS, chatRoomResponse);

--- a/backend/src/main/java/minionz/backend/chat/message/MessageService.java
+++ b/backend/src/main/java/minionz/backend/chat/message/MessageService.java
@@ -71,7 +71,7 @@ public class MessageService {
         }
 
         // 참가자들 목록
-        List<Long> participantIds = chatParticipationRepository.findById(chatRoomId).stream()
+        List<Long> participantIds = chatParticipationRepository.findByChatRoom_ChatRoomId(chatRoomId).stream()
                 .map(chatParticipation -> chatParticipation.getUser().getUserId())
                 .collect(Collectors.toList());
 


### PR DESCRIPTION
## 연관된 이슈
[#2,#20,#22]
<br>

## 작업 내용
- 채팅방을 생성 했을 때 구현 한 순서가 채팅 이름을 설정하고, 초대 할 사람을 선정했었습니다.
  - 선정 했을 때 채팅방 참가자들에 초대를 한 본인을 포함하고 있지 않아 포함하도록 설정 했습니다.
- 메세지를 보낼 때 response 응답 값으로 해당 방 참가자들에 대해서 받아오도록 해놨습니다. 
  - 원래는 userid를 통해 받아왔다면 chatRoomId를 통해서 받아오게 하여 해당 방에 참가하고 있는 사람들까지 응답할 수 있도록 설정 했습니다.
<br> 

## 전달 사항
close 했던 이슈들이라 open 이후에 다시 닫았습니다.
