### PR TITLE
[Fix] CHAT_003 - 읽지 않은 메세지, 최신 메세지 받아오는 값 수정 [#11]

### DIFF
--- a/backend/src/main/java/minionz/backend/chat/chat_room/ChatRoomService.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_room/ChatRoomService.java
@@ -82,7 +82,6 @@ public class ChatRoomService {
 
             // 채팅방에서 가장 최근 메시지를 가져옴
             Message latestMessage = findLatestMessage(chatRoom.getChatRoomId());
-            System.out.println(latestMessage.getMessageContents());
 
             // 읽지 않은 메시지 수 계산
             Long unreadMessagesCount = messageRepository.countUnreadMessagesByChatRoomIdAndUserId(
@@ -91,7 +90,7 @@ public class ChatRoomService {
             ReadChatRoomResponse response = ReadChatRoomResponse.builder()
                     .chatroomId(chatRoom.getChatRoomId())
                     .chatRoomName(chatRoom.getChatRoomName())
-                    .messageContents(latestMessage != null ? latestMessage.getMessageContents() : "No messages")
+                    .messageContents(latestMessage != null ? latestMessage.getMessageContents() : "채팅방에 메세지가 없습니다.")
                     .createdAt(latestMessage != null ? latestMessage.getCreatedAt() : chatRoom.getCreatedAt())
                     .UnreadMessages(unreadMessagesCount != null ? unreadMessagesCount.intValue() : 0)
                     .build();

--- a/backend/src/main/java/minionz/backend/chat/message/MessageRepository.java
+++ b/backend/src/main/java/minionz/backend/chat/message/MessageRepository.java
@@ -23,7 +23,11 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
                                                   Long userId,
                                                   MessageStatus status);
 
-    @Query("SELECT m FROM Message m WHERE m.chatParticipation.chatRoom.chatRoomId = :chatRoomId ORDER BY m.createdAt DESC")
+    @Query("SELECT m FROM Message m " +
+            "JOIN m.chatParticipation cp " +
+            "JOIN cp.chatRoom cr " +
+            "WHERE cr.chatRoomId = :chatRoomId " +
+            "ORDER BY m.createdAt DESC")
     List<Message> findLatestMessagesByChatRoomId(Long chatRoomId);
 
 

--- a/backend/src/main/java/minionz/backend/chat/message/MessageService.java
+++ b/backend/src/main/java/minionz/backend/chat/message/MessageService.java
@@ -7,6 +7,7 @@ import minionz.backend.chat.chat_participation.ChatParticipationRepository;
 import minionz.backend.chat.chat_participation.model.ChatParticipation;
 import minionz.backend.chat.chat_room.ChatRoomRepository;
 import minionz.backend.chat.message.model.Message;
+import minionz.backend.chat.message.model.MessageStatus;
 import minionz.backend.chat.message.model.MessageType;
 import minionz.backend.chat.message.model.request.MessageRequest;
 import minionz.backend.chat.message.model.response.MessageResponse;
@@ -30,7 +31,6 @@ public class MessageService {
     private final MessageRepository messageRepository;
     private final KafkaTemplate<String, String> kafkaTemplate;
     private final ObjectMapper objectMapper;
-    private final ChatRoomRepository chatRoomRepository;
     private final ChatParticipationRepository chatParticipationRepository;
     private final SimpMessagingTemplate messagingTemplate;
     private final CloudFileUpload cloudFileUpload;
@@ -55,6 +55,7 @@ public class MessageService {
                 .fileSize(files != null ? String.valueOf(files[0].getSize()) : null)
                 .fileType(files != null ? files[0].getContentType() : null)
                 .fileUrl(fileUrls != null && !fileUrls.isEmpty() ? fileUrls.get(0) : null)
+                .messageStatus(MessageStatus.UNREAD)
                 .build();
 
         Message savedMessage = messageRepository.save(message);


### PR DESCRIPTION
## 연관된 이슈
#11 
<br>

## 작업 내용
- 조회를 할 때 읽지 않은 메세지 값이 null이라 받아오지 못 하는 오류를 발견했습니다.
  - 실제 데이터 값을 넣어서 테스트 할 때 생긴 오류라 message를 보낼 때는 무조건 UNREAD로 설정되게 했습니다.
  - 추후에 어떤식으로 READ로 바뀌게 할지는 리팩토링하겠습니다.
- 최신 메세지를 받아올 때 제대로 값을 받아오지 않는 오류를 발견 했습니다.
  - repository에서 JPQL 쿼리를 변경하여 제대로 된 값을 불러올 수 있도록 수정했습니다.
  - 최신 메세지는 createAt를 기준으로 정렬되게 하여 가장 최신의 값 한 개만 받아오도록 했습니다.
<br> 

## 전달 사항
없습니다.
