### PR TITLE
[Feat] SCHEDULE_002, SCHEDULE_004 - 워크스페이스 주별 캘린더 조회 기능 및 개인 주별 캘린더 조회 기능 구현 [#106, #108]

### DIFF
--- a/backend/src/main/java/minionz/backend/common/responses/BaseResponseStatus.java
+++ b/backend/src/main/java/minionz/backend/common/responses/BaseResponseStatus.java
@@ -22,7 +22,7 @@ public enum BaseResponseStatus {
      */
     MY_WORKSPACE_READ_SUCCESS(true, 3001, "나의 워크스페이스 목록 조회를 성공했습니다."),
     MY_MONTHLY_READ_SUCCESS(true, 3002, "나의 월간 캘린더 조회에 성공했습니다."),
-
+    MY_WEEKLY_READ_SUCCESS(true, 3003, "나의 주간 캘린더 조회에 성공했습니다."),
 
     /**
      * 4000: 워크스페이스

--- a/backend/src/main/java/minionz/backend/common/responses/BaseResponseStatus.java
+++ b/backend/src/main/java/minionz/backend/common/responses/BaseResponseStatus.java
@@ -44,6 +44,7 @@ public enum BaseResponseStatus {
     TASK_STATUS_UPDATE_SUCCESS(true, 4015, "태스크 상태 변경에 성공했습니다."),
     SPRINT_STATUS_UPDATE_SUCCESS(true, 4016, "스프린트 상태 변경에 성공했습니다."),
     WORKSPACE_MONTHLY_READ_SUCCESS(true, 4017, "워크스페이스 월간 캘린더 조회에 성공했습니다."),
+    WORKSPACE_WEEKLY_READ_SUCCESS(true, 4018, "워크스페이스 주간 캘린더 조회에 성공했습니다."),
 
 
     WORKSPACE_ACCESS_DENIED(false, 4101, "워크스페이스에 접근 권한이 없습니다."),

--- a/backend/src/main/java/minionz/backend/scrum/issue/IssueRepository.java
+++ b/backend/src/main/java/minionz/backend/scrum/issue/IssueRepository.java
@@ -12,5 +12,10 @@ public interface IssueRepository extends JpaRepository<Issue, Long> {
             "JOIN i.workspace w " +
             "WHERE w.workspaceId = :workspaceId " +
             "AND i.status = true ")
-    List<Issue> findUpcomingIssues(Long workspaceId, Pageable pageable);
+    List<Issue> findUpcomingWorkspaceIssues(Long workspaceId, Pageable pageable);
+
+    @Query("SELECT i FROM Issue i " +
+            "WHERE i.user.userId = :userId " +
+            "AND i.status = true ")
+    List<Issue> findUpcomingMyIssues(Long userId, Pageable pageable);
 }

--- a/backend/src/main/java/minionz/backend/scrum/issue/IssueRepository.java
+++ b/backend/src/main/java/minionz/backend/scrum/issue/IssueRepository.java
@@ -1,7 +1,16 @@
 package minionz.backend.scrum.issue;
 
 import minionz.backend.scrum.issue.model.Issue;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface IssueRepository extends JpaRepository<Issue, Long> {
+    @Query("SELECT i FROM Issue i " +
+            "JOIN i.workspace w " +
+            "WHERE w.workspaceId = :workspaceId " +
+            "AND i.status = true ")
+    List<Issue> findUpcomingIssues(Long workspaceId, Pageable pageable);
 }

--- a/backend/src/main/java/minionz/backend/scrum/meeting/MeetingRepository.java
+++ b/backend/src/main/java/minionz/backend/scrum/meeting/MeetingRepository.java
@@ -16,12 +16,12 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
             "WHERE w.workspaceId = :workspaceId " +
             "AND m.startDate <= :endDate " +
             "AND m.startDate >= :startDate")
-    List<Meeting> findMeetingsInMonth(Long workspaceId, LocalDateTime startDate, LocalDateTime endDate);
+    List<Meeting> findMeetingsInPeriod(Long workspaceId, LocalDateTime startDate, LocalDateTime endDate);
 
     @Query("SELECT m FROM Meeting m " +
             "JOIN FETCH m.meetingParticipations mp " +
             "WHERE mp.user.userId = :userId " +
             "AND m.startDate <= :endDate " +
             "AND m.startDate >= :startDate")
-    List<Meeting> findMyMeetingsInMonth(Long userId, LocalDateTime startDate, LocalDateTime endDate);
+    List<Meeting> findMyMeetingsInPeriod(Long userId, LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/backend/src/main/java/minionz/backend/scrum/schedule/ScheduleController.java
+++ b/backend/src/main/java/minionz/backend/scrum/schedule/ScheduleController.java
@@ -7,6 +7,7 @@ import minionz.backend.common.responses.BaseResponse;
 import minionz.backend.common.responses.BaseResponseStatus;
 import minionz.backend.scrum.schedule.request.ReadScheduleRequest;
 import minionz.backend.scrum.schedule.response.ReadMonthlyResponse;
+import minionz.backend.scrum.schedule.response.ReadWeeklyResponse;
 import minionz.backend.user.model.User;
 import org.springframework.web.bind.annotation.*;
 
@@ -44,5 +45,19 @@ public class ScheduleController {
         }
 
         return new BaseResponse<>(BaseResponseStatus.MY_MONTHLY_READ_SUCCESS, response);
+    }
+
+    @GetMapping("/workspace/{workspaceId}/weekly")
+    public BaseResponse<ReadWeeklyResponse> readWorkspaceWeekly(@PathVariable Long workspaceId, ReadScheduleRequest request) {
+
+        ReadWeeklyResponse response;
+
+        try {
+            response = scheduleService.readWorkspaceWeekly(workspaceId, request);
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+
+        return new BaseResponse<>(BaseResponseStatus.WORKSPACE_MONTHLY_READ_SUCCESS, response);
     }
 }

--- a/backend/src/main/java/minionz/backend/scrum/schedule/ScheduleController.java
+++ b/backend/src/main/java/minionz/backend/scrum/schedule/ScheduleController.java
@@ -60,4 +60,19 @@ public class ScheduleController {
 
         return new BaseResponse<>(BaseResponseStatus.WORKSPACE_MONTHLY_READ_SUCCESS, response);
     }
+
+    @GetMapping("/myspace/weekly")
+    public BaseResponse<ReadWeeklyResponse> readMyspaceWeekly(ReadScheduleRequest request) {
+        User user = User.builder().userId(1L).build();
+
+        ReadWeeklyResponse response;
+
+        try {
+            response = scheduleService.readMyspaceWeekly(user, request);
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+
+        return new BaseResponse<>(BaseResponseStatus.MY_WEEKLY_READ_SUCCESS, response);
+    }
 }

--- a/backend/src/main/java/minionz/backend/scrum/schedule/ScheduleService.java
+++ b/backend/src/main/java/minionz/backend/scrum/schedule/ScheduleService.java
@@ -29,15 +29,15 @@ public class ScheduleService {
     private final IssueRepository issueRepository;
 
     public ReadMonthlyResponse readWorkspaceMonthly(Long workspaceId, ReadScheduleRequest request) {
-        List<Sprint> sprints = sprintRepository.findSprintsInMonth(workspaceId, request.getStartDate(), request.getEndDate());
-        List<Meeting> meetings = meetingRepository.findMeetingsInMonth(workspaceId, request.getStartDate(), request.getEndDate());
+        List<Sprint> sprints = sprintRepository.findSprintsInPeriod(workspaceId, request.getStartDate(), request.getEndDate());
+        List<Meeting> meetings = meetingRepository.findMeetingsInPeriod(workspaceId, request.getStartDate(), request.getEndDate());
 
         return makeMonthlyResponse(sprints, meetings);
     }
 
     public ReadMonthlyResponse readMyspaceMonthly(User user, ReadScheduleRequest request) {
-        List<Sprint> sprints = sprintRepository.findMySprintsInMonth(user.getUserId(), request.getStartDate(), request.getEndDate());
-        List<Meeting> meetings = meetingRepository.findMyMeetingsInMonth(user.getUserId(), request.getStartDate(), request.getEndDate());
+        List<Sprint> sprints = sprintRepository.findMySprintsInPeriod(user.getUserId(), request.getStartDate(), request.getEndDate());
+        List<Meeting> meetings = meetingRepository.findMyMeetingsInPeriod(user.getUserId(), request.getStartDate(), request.getEndDate());
 
         return makeMonthlyResponse(sprints, meetings);
     }
@@ -45,19 +45,24 @@ public class ScheduleService {
 
     public ReadWeeklyResponse readWorkspaceWeekly(Long workspaceId, ReadScheduleRequest request) {
         Pageable pageable = PageRequest.of(0, 3);
-        List<Sprint> sprints = sprintRepository.findSprintsInMonth(workspaceId, request.getStartDate(), request.getEndDate());
-        List<Meeting> meetings = meetingRepository.findMeetingsInMonth(workspaceId, request.getStartDate(), request.getEndDate());
-        List<Task> tasks = taskRepository.findUpcomingTasks(workspaceId, request.getStartDate(), request.getEndDate(), pageable);
-        List<Issue> issues = issueRepository.findUpcomingIssues(workspaceId, pageable);
 
-        return makeWeeklyResponse(sprints, meetings,tasks,issues);
+        List<Sprint> sprints = sprintRepository.findSprintsInPeriod(workspaceId, request.getStartDate(), request.getEndDate());
+        List<Meeting> meetings = meetingRepository.findMeetingsInPeriod(workspaceId, request.getStartDate(), request.getEndDate());
+        List<Task> tasks = taskRepository.findUpcomingWorkspaceTasks(workspaceId, request.getStartDate(), request.getEndDate(), pageable);
+        List<Issue> issues = issueRepository.findUpcomingWorkspaceIssues(workspaceId, pageable);
+
+        return makeWeeklyResponse(sprints, meetings, tasks, issues);
     }
 
-    public ReadMonthlyResponse readMyspaceWeekly(User user, ReadScheduleRequest request) {
-        List<Sprint> sprintResult = sprintRepository.findMySprintsInMonth(user.getUserId(), request.getStartDate(), request.getEndDate());
-        List<Meeting> meetingResult = meetingRepository.findMyMeetingsInMonth(user.getUserId(), request.getStartDate(), request.getEndDate());
+    public ReadWeeklyResponse readMyspaceWeekly(User user, ReadScheduleRequest request) {
+        Pageable pageable = PageRequest.of(0, 3);
 
-        return makeMonthlyResponse(sprintResult, meetingResult);
+        List<Sprint> sprints = sprintRepository.findMySprintsInPeriod(user.getUserId(), request.getStartDate(), request.getEndDate());
+        List<Meeting> meetings = meetingRepository.findMyMeetingsInPeriod(user.getUserId(), request.getStartDate(), request.getEndDate());
+        List<Task> tasks = taskRepository.findUpcomingMyTasks(user.getUserId(), request.getStartDate(), request.getEndDate(), pageable);
+        List<Issue> issues = issueRepository.findUpcomingMyIssues(user.getUserId(), pageable);
+
+        return makeWeeklyResponse(sprints, meetings, tasks, issues);
     }
 
     public ReadMonthlyResponse makeMonthlyResponse(List<Sprint> sprints, List<Meeting> meetings) {
@@ -117,7 +122,7 @@ public class ScheduleService {
                                         .builder()
                                         .title(issue.getIssueTitle())
                                         .description(issue.getIssueContents())
-                                        .managerId(issue.getUser().getLoginId())
+                                        .managerId(issue.getUser().getUserName())
                                         .build()).toList())
                 .build();
     }

--- a/backend/src/main/java/minionz/backend/scrum/schedule/ScheduleService.java
+++ b/backend/src/main/java/minionz/backend/scrum/schedule/ScheduleService.java
@@ -1,16 +1,21 @@
 package minionz.backend.scrum.schedule;
 
 import lombok.RequiredArgsConstructor;
+import minionz.backend.scrum.issue.IssueRepository;
+import minionz.backend.scrum.issue.model.Issue;
 import minionz.backend.scrum.meeting.MeetingRepository;
 import minionz.backend.scrum.meeting.model.Meeting;
 import minionz.backend.scrum.schedule.request.ReadScheduleRequest;
-import minionz.backend.scrum.schedule.response.MeetingResponse;
-import minionz.backend.scrum.schedule.response.ReadMonthlyResponse;
-import minionz.backend.scrum.schedule.response.SprintResponse;
+import minionz.backend.scrum.schedule.response.*;
 import minionz.backend.scrum.sprint.SprintRepository;
 import minionz.backend.scrum.sprint.model.Sprint;
+import minionz.backend.scrum.sprint.model.response.Label;
 import minionz.backend.scrum.sprint.model.response.Participant;
+import minionz.backend.scrum.task.TaskRepository;
+import minionz.backend.scrum.task.model.Task;
 import minionz.backend.user.model.User;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -20,43 +25,101 @@ import java.util.List;
 public class ScheduleService {
     private final SprintRepository sprintRepository;
     private final MeetingRepository meetingRepository;
+    private final TaskRepository taskRepository;
+    private final IssueRepository issueRepository;
 
     public ReadMonthlyResponse readWorkspaceMonthly(Long workspaceId, ReadScheduleRequest request) {
-        List<Sprint> sprintResult = sprintRepository.findSprintsInMonth(workspaceId, request.getStartDate(), request.getEndDate());
-        List<Meeting> meetingResult = meetingRepository.findMeetingsInMonth(workspaceId, request.getStartDate(), request.getEndDate());
+        List<Sprint> sprints = sprintRepository.findSprintsInMonth(workspaceId, request.getStartDate(), request.getEndDate());
+        List<Meeting> meetings = meetingRepository.findMeetingsInMonth(workspaceId, request.getStartDate(), request.getEndDate());
 
-        return makeResponse(sprintResult, meetingResult);
+        return makeMonthlyResponse(sprints, meetings);
     }
 
     public ReadMonthlyResponse readMyspaceMonthly(User user, ReadScheduleRequest request) {
+        List<Sprint> sprints = sprintRepository.findMySprintsInMonth(user.getUserId(), request.getStartDate(), request.getEndDate());
+        List<Meeting> meetings = meetingRepository.findMyMeetingsInMonth(user.getUserId(), request.getStartDate(), request.getEndDate());
+
+        return makeMonthlyResponse(sprints, meetings);
+    }
+
+
+    public ReadWeeklyResponse readWorkspaceWeekly(Long workspaceId, ReadScheduleRequest request) {
+        Pageable pageable = PageRequest.of(0, 3);
+        List<Sprint> sprints = sprintRepository.findSprintsInMonth(workspaceId, request.getStartDate(), request.getEndDate());
+        List<Meeting> meetings = meetingRepository.findMeetingsInMonth(workspaceId, request.getStartDate(), request.getEndDate());
+        List<Task> tasks = taskRepository.findUpcomingTasks(workspaceId, request.getStartDate(), request.getEndDate(), pageable);
+        List<Issue> issues = issueRepository.findUpcomingIssues(workspaceId, pageable);
+
+        return makeWeeklyResponse(sprints, meetings,tasks,issues);
+    }
+
+    public ReadMonthlyResponse readMyspaceWeekly(User user, ReadScheduleRequest request) {
         List<Sprint> sprintResult = sprintRepository.findMySprintsInMonth(user.getUserId(), request.getStartDate(), request.getEndDate());
         List<Meeting> meetingResult = meetingRepository.findMyMeetingsInMonth(user.getUserId(), request.getStartDate(), request.getEndDate());
 
-        return makeResponse(sprintResult, meetingResult);
+        return makeMonthlyResponse(sprintResult, meetingResult);
     }
 
-    public ReadMonthlyResponse makeResponse(List<Sprint> sprintResult,List<Meeting> meetingResult ){
+    public ReadMonthlyResponse makeMonthlyResponse(List<Sprint> sprints, List<Meeting> meetings) {
         return ReadMonthlyResponse
                 .builder()
-                .sprints(sprintResult.stream().map(
+                .sprints(sprints.stream().map(
                         sprint -> SprintResponse
                                 .builder()
                                 .id(sprint.getSprintId())
                                 .title(sprint.getSprintTitle())
                                 .startDate(sprint.getStartDate())
                                 .endDate(sprint.getEndDate())
-                                .build()
+                                .build()).toList())
+                .meetings(meetings.stream().map(
+                        meeting -> MeetingResponse
+                                .builder()
+                                .id(meeting.getMeetingId())
+                                .title(meeting.getMeetingTitle())
+                                .startDate(meeting.getStartDate())
+                                .participants(findParticipants(meeting))
+                                .build()).toList())
+                .build();
+    }
 
-                ).toList())
-                .meetings( meetingResult.stream().map(
-                meeting -> MeetingResponse
-                        .builder()
-                        .id(meeting.getMeetingId())
-                        .title(meeting.getMeetingTitle())
-                        .startDate(meeting.getStartDate())
-                        .participants(findParticipants(meeting))
-                        .build()
-        ).toList()).build();
+    public ReadWeeklyResponse makeWeeklyResponse(List<Sprint> sprints, List<Meeting> meetings, List<Task> tasks, List<Issue> issues) {
+        return ReadWeeklyResponse
+                .builder()
+                .sprints(sprints.stream().map(
+                        sprint -> SprintResponse
+                                .builder()
+                                .id(sprint.getSprintId())
+                                .title(sprint.getSprintTitle())
+                                .startDate(sprint.getStartDate())
+                                .endDate(sprint.getEndDate())
+                                .build()).toList())
+                .meetings(meetings.stream().map(
+                        meeting -> MeetingResponse
+                                .builder()
+                                .id(meeting.getMeetingId())
+                                .title(meeting.getMeetingTitle())
+                                .startDate(meeting.getStartDate())
+                                .participants(findParticipants(meeting))
+                                .build()).toList())
+                .tasks(
+                        tasks.stream().map(
+                                task -> TaskResponse
+                                        .builder()
+                                        .id(task.getTaskId())
+                                        .title(task.getTaskTitle())
+                                        .endDate(task.getEndDate())
+                                        .priority(task.getPriority())
+                                        .labels(findLabels(task))
+                                        .build()).toList())
+                .issues(
+                        issues.stream().map(
+                                issue -> IssueResponse
+                                        .builder()
+                                        .title(issue.getIssueTitle())
+                                        .description(issue.getIssueContents())
+                                        .managerId(issue.getUser().getLoginId())
+                                        .build()).toList())
+                .build();
     }
 
     public List<Participant> findParticipants(Meeting meeting) {
@@ -65,7 +128,18 @@ public class ScheduleService {
                         .id(participant.getUser().getUserId())
                         .userName(participant.getUser().getUserName())
                         .isManager(true)
-                        .build()
-        ).toList();
+                        .build()).toList();
     }
+
+    public List<Label> findLabels(Task task) {
+        return task.getTaskLabelSelects().stream().map(
+                label -> Label
+                        .builder()
+                        .id(label.getTaskLabel().getTaskLabelId())
+                        .labelName(label.getTaskLabel().getLabelName())
+                        .color(label.getTaskLabel().getColor())
+                        .build()).toList();
+    }
+
+
 }

--- a/backend/src/main/java/minionz/backend/scrum/schedule/response/IssueResponse.java
+++ b/backend/src/main/java/minionz/backend/scrum/schedule/response/IssueResponse.java
@@ -1,0 +1,13 @@
+package minionz.backend.scrum.schedule.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import minionz.backend.scrum.sprint.model.response.Participant;
+
+@Builder
+@Getter
+public class IssueResponse {
+    private String title;
+    private String description;
+    private String managerId;
+}

--- a/backend/src/main/java/minionz/backend/scrum/schedule/response/ReadWeeklyResponse.java
+++ b/backend/src/main/java/minionz/backend/scrum/schedule/response/ReadWeeklyResponse.java
@@ -1,0 +1,15 @@
+package minionz.backend.scrum.schedule.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class ReadWeeklyResponse {
+    private List<SprintResponse> sprints;
+    private List<MeetingResponse> meetings;
+    private List<TaskResponse> tasks;
+    private List<IssueResponse> issues;
+}

--- a/backend/src/main/java/minionz/backend/scrum/schedule/response/TaskResponse.java
+++ b/backend/src/main/java/minionz/backend/scrum/schedule/response/TaskResponse.java
@@ -1,0 +1,19 @@
+package minionz.backend.scrum.schedule.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import minionz.backend.scrum.sprint.model.response.Label;
+import minionz.backend.scrum.task.model.TaskLevel;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+@Getter
+public class TaskResponse {
+    private Long id;
+    private String title;
+    private LocalDateTime endDate;
+    private TaskLevel priority;
+    private List<Label> labels;
+}

--- a/backend/src/main/java/minionz/backend/scrum/sprint/SprintRepository.java
+++ b/backend/src/main/java/minionz/backend/scrum/sprint/SprintRepository.java
@@ -15,13 +15,13 @@ public interface SprintRepository extends JpaRepository<Sprint, Long> {
             "WHERE w.workspaceId = :workspaceId " +
             "AND s.startDate <= :endDate " +
             "AND s.endDate >= :startDate")
-    List<Sprint> findSprintsInMonth(Long workspaceId, LocalDateTime startDate, LocalDateTime endDate);
+    List<Sprint> findSprintsInPeriod(Long workspaceId, LocalDateTime startDate, LocalDateTime endDate);
 
     @Query("SELECT s FROM Sprint s " +
             "JOIN FETCH s.sprintParticipations sp " +
             "WHERE sp.user.userId = :userId " +
             "AND s.startDate <= :endDate " +
             "AND s.endDate >= :startDate")
-    List<Sprint> findMySprintsInMonth(Long userId, LocalDateTime startDate, LocalDateTime endDate);
+    List<Sprint> findMySprintsInPeriod(Long userId, LocalDateTime startDate, LocalDateTime endDate);
 
 }

--- a/backend/src/main/java/minionz/backend/scrum/task/TaskRepository.java
+++ b/backend/src/main/java/minionz/backend/scrum/task/TaskRepository.java
@@ -1,9 +1,11 @@
 package minionz.backend.scrum.task;
 
 import minionz.backend.scrum.task.model.Task;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface TaskRepository extends JpaRepository<Task, Long> {
@@ -19,6 +21,15 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
            "JOIN FETCH Sprint s ON t.sprint = s " +
            "WHERE tp.user.userId = :userId AND s.endDate > CURRENT_TIMESTAMP")
    List<Task> findMyTask(Long userId);
+
+
+    @Query("SELECT t FROM Task t " +
+            "JOIN FETCH t.sprint s " +
+            "JOIN s.workspace w " +
+            "WHERE w.workspaceId = :workspaceId " +
+            "AND t.startDate <= :endDate " +
+            "AND t.endDate >= :startDate ORDER BY t.endDate ASC ")
+    List<Task> findUpcomingTasks(Long workspaceId, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
 }
 
 

--- a/backend/src/main/java/minionz/backend/scrum/task/TaskRepository.java
+++ b/backend/src/main/java/minionz/backend/scrum/task/TaskRepository.java
@@ -29,7 +29,15 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
             "WHERE w.workspaceId = :workspaceId " +
             "AND t.startDate <= :endDate " +
             "AND t.endDate >= :startDate ORDER BY t.endDate ASC ")
-    List<Task> findUpcomingTasks(Long workspaceId, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
+    List<Task> findUpcomingWorkspaceTasks(Long workspaceId, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
+
+    @Query("SELECT t FROM Task t " +
+            "JOIN FETCH TaskParticipation tp ON t = tp.task " +
+            "JOIN FETCH t.sprint s " +
+            "WHERE tp.user.userId = :userId " +
+            "AND t.startDate <= :endDate " +
+            "AND t.endDate >= :startDate ORDER BY t.endDate ASC ")
+    List<Task> findUpcomingMyTasks(Long userId, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
 }
 
 


### PR DESCRIPTION
## 연관된 이슈
#106 #108 
<br>

## 작업 내용
- 워크스페이스의 주별 캘린더 조회 기능을 구현했습니다.
- 로그인 한 유저의 주별 캘린더 조회 기능을 구현했습니다.
- 해당 주가 시작일과 마감일 사이에 포함된 회의와 스프린트, 다가오는 이슈와 태스크를 마감 임박순으로 3개씩 조회하는 기능입니다.
<br> 

## 전달 사항

close #106 
close #108 
