### PR TITLE
[Feat] DASHBOARD_001 - 워크스페이스 대시보드 조회 기능 구현 [#109]

### DIFF
--- a/backend/src/main/java/minionz/backend/scrum/dashboard/DashboardController.java
+++ b/backend/src/main/java/minionz/backend/scrum/dashboard/DashboardController.java
@@ -7,8 +7,10 @@ import minionz.backend.common.responses.BaseResponse;
 import minionz.backend.common.responses.BaseResponseStatus;
 import minionz.backend.scrum.dashboard.model.request.ReadMyDashboardRequest;
 import minionz.backend.scrum.dashboard.model.response.ReadMyDashboardResponse;
+import minionz.backend.scrum.dashboard.model.response.ReadWorkspaceDashboardResponse;
 import minionz.backend.user.model.User;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,7 +28,20 @@ public class DashboardController {
 
         try {
             response = dashboardService.readMyDashboard(user, request);
-        } catch (BaseException e){
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+
+        return new BaseResponse<>(BaseResponseStatus.MY_DASHBOARD_READ_SUCCESS, response);
+    }
+
+    @GetMapping("/workspace/{workspaceId}")
+    public BaseResponse<ReadWorkspaceDashboardResponse> readWorkspaceDashboard(@PathVariable Long workspaceId, ReadMyDashboardRequest request) {
+        ReadWorkspaceDashboardResponse response;
+
+        try {
+            response = dashboardService.readWorkspaceDashboard(workspaceId, request);
+        } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
         }
 

--- a/backend/src/main/java/minionz/backend/scrum/dashboard/model/response/MyProgressResponse.java
+++ b/backend/src/main/java/minionz/backend/scrum/dashboard/model/response/MyProgressResponse.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class ProgressResponse {
+public class MyProgressResponse {
     private int workspaceCount;
     private int allTaskCount;
     private int successTaskCount;

--- a/backend/src/main/java/minionz/backend/scrum/dashboard/model/response/ReadMyDashboardResponse.java
+++ b/backend/src/main/java/minionz/backend/scrum/dashboard/model/response/ReadMyDashboardResponse.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Getter
 @Builder
 public class ReadMyDashboardResponse {
-    private ProgressResponse progress;
+    private MyProgressResponse progress;
     private List<PriorityTaskResponse> priorityTasks;
     private List<UpcomingMyMeetingResponse> upcomingMeetings;
 }

--- a/backend/src/main/java/minionz/backend/scrum/dashboard/model/response/ReadWorkspaceDashboardResponse.java
+++ b/backend/src/main/java/minionz/backend/scrum/dashboard/model/response/ReadWorkspaceDashboardResponse.java
@@ -1,0 +1,13 @@
+package minionz.backend.scrum.dashboard.model.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ReadWorkspaceDashboardResponse {
+    private WorkspaceProgressResponse progress;
+    private List<UpcomingMyMeetingResponse> upcomingMeetings;
+}

--- a/backend/src/main/java/minionz/backend/scrum/dashboard/model/response/UpcomingMyMeetingResponse.java
+++ b/backend/src/main/java/minionz/backend/scrum/dashboard/model/response/UpcomingMyMeetingResponse.java
@@ -11,5 +11,6 @@ public class UpcomingMyMeetingResponse {
     private Long id;
     private String title;
     private String workspaceName;
+    private String sprintName;
     private LocalDateTime startDate;
 }

--- a/backend/src/main/java/minionz/backend/scrum/dashboard/model/response/WorkspaceProgressResponse.java
+++ b/backend/src/main/java/minionz/backend/scrum/dashboard/model/response/WorkspaceProgressResponse.java
@@ -1,0 +1,14 @@
+package minionz.backend.scrum.dashboard.model.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class WorkspaceProgressResponse {
+    private int sprintCount;
+    private int allSprintCount;
+    private int allTaskCount;
+    private int successTaskCount;
+    private int issueCount;
+}

--- a/backend/src/main/java/minionz/backend/scrum/issue/IssueRepository.java
+++ b/backend/src/main/java/minionz/backend/scrum/issue/IssueRepository.java
@@ -18,4 +18,10 @@ public interface IssueRepository extends JpaRepository<Issue, Long> {
             "WHERE i.user.userId = :userId " +
             "AND i.status = true ")
     List<Issue> findUpcomingMyIssues(Long userId, Pageable pageable);
+
+    @Query("SELECT COUNT(i) FROM Issue i " +
+            "JOIN i.workspace w " +
+            "WHERE w.workspaceId = :workspaceId " +
+            "AND i.status = true ")
+    int findWorkspaceIssuesCount(Long workspaceId);
 }

--- a/backend/src/main/java/minionz/backend/scrum/sprint/SprintRepository.java
+++ b/backend/src/main/java/minionz/backend/scrum/sprint/SprintRepository.java
@@ -24,4 +24,16 @@ public interface SprintRepository extends JpaRepository<Sprint, Long> {
             "AND s.endDate >= :startDate")
     List<Sprint> findMySprintsInPeriod(Long userId, LocalDateTime startDate, LocalDateTime endDate);
 
+    @Query("SELECT COUNT(s) FROM Sprint s " +
+            "JOIN s.workspace w " +
+            "WHERE w.workspaceId = :workspaceId " +
+            "AND s.startDate <= :endDate " +
+            "AND s.endDate >= :startDate")
+    int findInprogressSprintCount(Long workspaceId, LocalDateTime startDate, LocalDateTime endDate);
+
+    @Query("SELECT COUNT(s) FROM Sprint s " +
+            "JOIN s.workspace w " +
+            "WHERE w.workspaceId = :workspaceId ")
+    int findAllSprintCount(Long workspaceId);
+
 }

--- a/backend/src/main/java/minionz/backend/scrum/task/TaskRepository.java
+++ b/backend/src/main/java/minionz/backend/scrum/task/TaskRepository.java
@@ -63,6 +63,21 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
             "END ASC")
     List<Task> findPriorityMyTasks(Long userId, Pageable pageable);
 
+
+    @Query("SELECT COUNT(t) FROM Task t " +
+            "JOIN FETCH Sprint s ON t.sprint = s " +
+            "JOIN FETCH Workspace w ON s.workspace = w " +
+            "WHERE w.workspaceId = :workspaceId " +
+            "AND s.endDate > CURRENT_TIMESTAMP ")
+    int findAllTaskCount(Long workspaceId);
+
+    @Query("SELECT COUNT(t) FROM Task t " +
+            "JOIN FETCH Sprint s ON t.sprint = s " +
+            "JOIN FETCH Workspace w ON s.workspace = w " +
+            "WHERE w.workspaceId = :workspaceId " +
+            "AND s.endDate > CURRENT_TIMESTAMP " +
+            "AND t.status = minionz.backend.scrum.task.model.TaskStatus.DONE")
+    int findSuccessTaskCount(Long workspaceId);
 }
 
 


### PR DESCRIPTION
## 연관된 이슈
#109 
<br>

## 작업 내용
- 번다운 차트를 제외한 워크스페이스의 대시보드 조회 기능을 구현했습니다.
- progress의 sprint count는 마감일이 끝나지 않은 sprint의 개수를 반환합니다.
- progress의 task count는 sprint 마감일이 끝나지 않은 task의 개수를 반환합니다.
- upcoming meetings는 앞으로 2주동안 진행될 회의들에 대해 반환합니다.
<br> 

## 전달 사항
- 번다운 차트를 구현하여 워크스페이스 대시보드 조회 기능 구현을 완료할 예정입니다.
