### PR TITLE
[Fix] CHAT_005,006 - 파일 전송 환경 변경 [#20, #22]

### DIFF
--- a/backend/src/main/java/minionz/backend/chat/message/MessageController.java
+++ b/backend/src/main/java/minionz/backend/chat/message/MessageController.java
@@ -22,7 +22,7 @@ public class MessageController {
     }
 
     // 파일 전송
-    @MessageMapping("/room/{chatRoomId}/sendFile")
+    @PostMapping("/message/sendFile")
     public void sendFile(
             @RequestParam("chatRoomId") Long chatRoomId,
             @RequestPart(name = "files") MultipartFile[] files,


### PR DESCRIPTION
## 연관된 이슈
#20 , #22 
<br>

## 작업 내용
- WebSocket으로 파일을 주고 받을 수 있을 줄 알았는데 안 된다는 것을 확인 했습니다.
  - 기존 구현 방식대로 메세지는 WebSocket을 써서 받을 수 있게 하고,  파일은 multipart/form-data 으로 처리하도록 해야 하기에 REST API로 처리하도록 변경 했습니다.
<br> 

## 전달 사항
원래는 response로 파일에 대한 정보까지 보낼 수 있도록 했는데, 이 부분은 채팅내역 조회에서 join 해서 값을 가지고 오도록 구현 해 두겠습니다.
