### PR TITLE
[Fix] CHAT_005,006 - 모든 도메인 접근 허용 [#20, #22]

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
-    //amamzon s3
+    //amazon s3
     implementation group: 'io.awspring.cloud', name: 'spring-cloud-starter-aws', version: '2.4.2'
     //kafka
     implementation 'org.springframework.kafka:spring-kafka'

--- a/backend/src/main/java/minionz/backend/config/web/WebSocketConfig.java
+++ b/backend/src/main/java/minionz/backend/config/web/WebSocketConfig.java
@@ -13,7 +13,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/chat")
-                .setAllowedOriginPatterns("*") // 모든 도메인에서의 CORS 허용
+                .setAllowedOrigins("*") // 모든 도메인에서의 CORS 허용
                 .withSockJS();
     }
 


### PR DESCRIPTION
## 연관된 이슈
#20 #22 
<br>

## 작업 내용
- amazon s3 오타 이름 변경했습니다.
- 프론트와 백엔드 연결 과정에서 cors 에러로 인해 모든 도메인에서 접근 가능하도록 허용 해 줬습니다.
<br> 

## 전달 사항
없습니다.
