### PR TITLE
[Feat] CHAT_007 - 채팅 내역 조회 기능 [#25]

### DIFF
--- a/backend/src/main/java/minionz/backend/chat/chat_room/model/response/ReadMessageResponse.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_room/model/response/ReadMessageResponse.java
@@ -1,0 +1,35 @@
+package minionz.backend.chat.chat_room.model.response;
+
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.Builder;
+import lombok.Getter;
+import minionz.backend.chat.message.model.MessageStatus;
+import minionz.backend.chat.message.model.MessageType;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+public class ReadMessageResponse {
+    private Long messageId;
+    private Long senderId;
+
+    private String userName;
+    private String messageContents;
+    private LocalDateTime createdAt;
+
+    @Enumerated(EnumType.STRING)
+    private MessageType messageType;
+
+    @Enumerated(EnumType.STRING)
+    private MessageStatus messageStatus;
+
+    private String fileType;
+    private String fileSize;
+    private String fileUrl;
+    private String fileName;
+
+    private Integer persona; // 프로필 이미지
+
+}

--- a/backend/src/main/java/minionz/backend/chat/message/MessageController.java
+++ b/backend/src/main/java/minionz/backend/chat/message/MessageController.java
@@ -1,12 +1,18 @@
 package minionz.backend.chat.message;
 
 import lombok.RequiredArgsConstructor;
+import minionz.backend.chat.chat_room.model.response.ReadMessageResponse;
 import minionz.backend.chat.message.model.request.MessageRequest;
+import minionz.backend.common.responses.BaseResponse;
+import minionz.backend.common.responses.BaseResponseStatus;
 import minionz.backend.user.model.CustomSecurityUserDetails;
+import minionz.backend.user.model.User;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -33,6 +39,13 @@ public class MessageController {
         request.setChatRoomId(chatRoomId);
         // 파일 처리
         messageService.sendMessage(chatRoomId, request, files, senderId);
+    }
+
+    @GetMapping(value = "/message/{chatRoomId}")
+    public BaseResponse<List<ReadMessageResponse>> readMessage(@AuthenticationPrincipal CustomSecurityUserDetails customUserDetails, @PathVariable Long chatRoomId) {
+        User user = customUserDetails.getUser();
+        List<ReadMessageResponse> response = messageService.readMessage(chatRoomId, user.getUserId());
+        return new BaseResponse<>(BaseResponseStatus.CHAT_HISTORY_RETRIEVAL_SUCCESS, response);
     }
 }
 

--- a/backend/src/main/java/minionz/backend/chat/message/MessageRepository.java
+++ b/backend/src/main/java/minionz/backend/chat/message/MessageRepository.java
@@ -30,6 +30,8 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
             "ORDER BY m.createdAt DESC")
     List<Message> findLatestMessagesByChatRoomId(Long chatRoomId);
 
+    List<Message> findByChatParticipation_ChatRoom_ChatRoomIdOrderByCreatedAtAsc(Long chatRoomId);
+
 
 
 

--- a/backend/src/main/java/minionz/backend/common/responses/BaseResponseStatus.java
+++ b/backend/src/main/java/minionz/backend/common/responses/BaseResponseStatus.java
@@ -84,7 +84,12 @@ public enum BaseResponseStatus {
     CHATROOM_LIST_FAIL(false, 6102, "채팅방 조회에 실패했습니다."),
     MESSAGE_SEND_SUCCESS(true, 6201, "메세지가 성공적으로 전송되었습니다."),
     MESSAGE_SEND_FAIL(false, 6202, "메세지가 전송되지 않았습니다."),
-    CHAT_PARTICIPATION_NOT_FOUND(false, 6203, "참여자가 존재하지 않습니다.");
+    CHAT_PARTICIPATION_NOT_FOUND(false, 6203, "참여자가 존재하지 않습니다."),
+    CHAT_HISTORY_RETRIEVAL_SUCCESS(true, 6301, "채팅 내역 조회에 성공했습니다."),
+    CHAT_ROOM_NOT_FOUND(false, 6302, "해당 채팅방을 찾을 수 없습니다."),
+    MESSAGE_HISTORY_NOT_FOUND(false, 6303, "해당 채팅방에 메시지 내역이 없습니다."),
+    UNAUTHORIZED_CHAT_ACCESS(false, 6304, "해당 채팅방에 접근할 권한이 없습니다."),
+    FAILED_TO_RETRIEVE_CHAT_HISTORY(false, 6305, "채팅 내역 조회에 실패했습니다.");
 
 
 


### PR DESCRIPTION
## 연관된 이슈
 #25
<br>

## 작업 내용
- baseResponse에 채팅 내역 조회에 대한 상태 코드들을 추가 했습니다.
- 로그인 한 유저가 선택한 채팅방에 대한 채팅 내역을 받아오도록 했습니다.
<br> 

## 전달 사항
close #25
