### PR TITLE
[Feat] CHAT_008 - 채팅 수정 기능 구현 [#26]

### DIFF
--- a/backend/src/main/java/minionz/backend/chat/chat_participation/ChatParticipationRepository.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_participation/ChatParticipationRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 public interface ChatParticipationRepository extends JpaRepository<ChatParticipation, Long> {
     List<ChatParticipation> findByUser_UserId(Long userId);
-    List<ChatParticipation> findByChatRoom_ChatRoomId(Long chatRoomId);
+    List<ChatParticipation> findAllByUser_UserId(Long userId);
     ChatParticipation findByChatRoom_ChatRoomIdAndUser_UserId(Long chatRoomId, Long userId);
 }
 

--- a/backend/src/main/java/minionz/backend/chat/chat_room/model/response/ReadMessageResponse.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_room/model/response/ReadMessageResponse.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import minionz.backend.chat.message.model.MessageStatus;
 import minionz.backend.chat.message.model.MessageType;
+import minionz.backend.chat.message.model.request.FileInfo;
 
 import java.time.LocalDateTime;
 
@@ -24,12 +25,7 @@ public class ReadMessageResponse {
 
     @Enumerated(EnumType.STRING)
     private MessageStatus messageStatus;
-
-    private String fileType;
-    private String fileSize;
-    private String fileUrl;
-    private String fileName;
-
+    private FileInfo file;
     private Integer persona; // 프로필 이미지
 
 }

--- a/backend/src/main/java/minionz/backend/chat/message/MessageController.java
+++ b/backend/src/main/java/minionz/backend/chat/message/MessageController.java
@@ -2,12 +2,14 @@ package minionz.backend.chat.message;
 
 import lombok.RequiredArgsConstructor;
 import minionz.backend.chat.chat_room.model.response.ReadMessageResponse;
-import minionz.backend.chat.message.model.request.MessageRequest;
+import minionz.backend.chat.message.model.request.SendMessageRequest;
+import minionz.backend.chat.message.model.request.UpdateMessageRequest;
 import minionz.backend.common.responses.BaseResponse;
 import minionz.backend.common.responses.BaseResponseStatus;
 import minionz.backend.user.model.CustomSecurityUserDetails;
 import minionz.backend.user.model.User;
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -22,8 +24,8 @@ public class MessageController {
 
     // 메세지 전송
     @MessageMapping("/room/{chatRoomId}/send")
-    public void sendMessage(MessageRequest request, @AuthenticationPrincipal CustomSecurityUserDetails userDetails) {
-        Long senderId = userDetails.getUser().getUserId();
+    public void sendMessage(@Payload SendMessageRequest request, @AuthenticationPrincipal CustomSecurityUserDetails customUserDetails) {
+        Long senderId = customUserDetails.getUser().getUserId();
         messageService.sendMessage(request.getChatRoomId(), request, null, senderId);
     }
 
@@ -32,20 +34,28 @@ public class MessageController {
     public void sendFile(
             @RequestParam("chatRoomId") Long chatRoomId,
             @RequestPart(name = "files") MultipartFile[] files,
-            @AuthenticationPrincipal CustomSecurityUserDetails userDetails) {
+            @AuthenticationPrincipal CustomSecurityUserDetails customUserDetails) {
 
-        Long senderId = userDetails.getUser().getUserId();
-        MessageRequest request = new MessageRequest();
+        Long senderId = customUserDetails.getUser().getUserId();
+        SendMessageRequest request = new SendMessageRequest();
         request.setChatRoomId(chatRoomId);
         // 파일 처리
         messageService.sendMessage(chatRoomId, request, files, senderId);
     }
 
+    // 채팅 내역 조회
     @GetMapping(value = "/message/{chatRoomId}")
     public BaseResponse<List<ReadMessageResponse>> readMessage(@AuthenticationPrincipal CustomSecurityUserDetails customUserDetails, @PathVariable Long chatRoomId) {
         User user = customUserDetails.getUser();
         List<ReadMessageResponse> response = messageService.readMessage(chatRoomId, user.getUserId());
         return new BaseResponse<>(BaseResponseStatus.CHAT_HISTORY_RETRIEVAL_SUCCESS, response);
     }
+
+    @MessageMapping("/room/{chatRoomId}/edit")
+    public void updateMessage(@Payload UpdateMessageRequest request, @AuthenticationPrincipal CustomSecurityUserDetails customUserDetails) {
+        Long senderId = customUserDetails.getUser().getUserId();
+        messageService.updateMessage(request.getChatRoomId(), request, senderId);
+    }
+
 }
 

--- a/backend/src/main/java/minionz/backend/chat/message/MessageRepository.java
+++ b/backend/src/main/java/minionz/backend/chat/message/MessageRepository.java
@@ -32,7 +32,8 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
 
     List<Message> findByChatParticipation_ChatRoom_ChatRoomIdOrderByCreatedAtAsc(Long chatRoomId);
 
-
+    @Query("SELECT m FROM Message m WHERE m.messageId = :messageId")
+    Message findMessageById(Long messageId);
 
 
 

--- a/backend/src/main/java/minionz/backend/chat/message/model/request/FileInfo.java
+++ b/backend/src/main/java/minionz/backend/chat/message/model/request/FileInfo.java
@@ -1,0 +1,15 @@
+package minionz.backend.chat.message.model.request;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FileInfo {
+    private String fileType;
+    private String fileSize;
+    private String fileUrl;
+    private String fileName;
+}

--- a/backend/src/main/java/minionz/backend/chat/message/model/request/SendMessageRequest.java
+++ b/backend/src/main/java/minionz/backend/chat/message/model/request/SendMessageRequest.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class MessageRequest {
+public class SendMessageRequest {
 
     private String messageContents;
     private List<String> files;

--- a/backend/src/main/java/minionz/backend/chat/message/model/request/UpdateMessageRequest.java
+++ b/backend/src/main/java/minionz/backend/chat/message/model/request/UpdateMessageRequest.java
@@ -1,0 +1,16 @@
+package minionz.backend.chat.message.model.request;
+
+import lombok.*;
+
+@Getter
+@Builder(toBuilder = true)
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateMessageRequest {
+    private Long chatRoomId;
+    private Long messageId;
+    private String userName;
+    private String messageContents;
+
+}


### PR DESCRIPTION
## 연관된 이슈
#26 
<br>

## 작업 내용
- messageRequest 부분에서 한 번에 처리 하려다가 send와 update로 받는 값이 많이 다르기에 통합하지 않고 구분했습니다.
  - 구분하는 과정에서 send 부분을 rename해서  MessageRequest -> SendMessageRequest 로 변경 했습니다.
- 채팅 내역을 조회하는 과정에서 file과 message 부분을 같이 응답 해 주고 있었습니다.
  - 프론트에서 페이지 불러올 때 필터링 과정을 생각 해 리스트 형식으로 반환이 필요함을 요청 받았습니다.
  - fileInfo를 만들어 그 안에서 file에 대한 내용들을 관리하도록 변경 했습니다.
- 채팅을 수정하는 기능을 구현 했습니다.
<br> 

## 전달 사항
close #26
