### PR TITLE
[Feat] CHAT_001,009 - 채팅 삭제 기능 구현 및 채팅방 생성 수정 [#2, #27]

### DIFF
--- a/backend/src/main/java/minionz/backend/chat/chat_room/ChatRoomController.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_room/ChatRoomController.java
@@ -26,11 +26,10 @@ public class ChatRoomController {
         return new BaseResponse<>(BaseResponseStatus.CHATROOM_CREATE_SUCCESS, response);
     }
 
-    @GetMapping(value = "/roomList")
-    public BaseResponse<List<ReadChatRoomResponse>> readRoomList(@AuthenticationPrincipal CustomSecurityUserDetails customUserDetails) {
+    @GetMapping(value = "/{workspaceId}/roomList")
+    public BaseResponse<List<ReadChatRoomResponse>> readRoomList(@PathVariable Long workspaceId, @AuthenticationPrincipal CustomSecurityUserDetails customUserDetails) {
         User user = customUserDetails.getUser();
-        List<ReadChatRoomResponse> response = chatRoomService.roomList(user.getUserId());
+        List<ReadChatRoomResponse> response = chatRoomService.roomList(user.getUserId(), workspaceId);
         return new BaseResponse<>(BaseResponseStatus.CHATROOM_LIST_SUCCESS, response);
     }
-
 }

--- a/backend/src/main/java/minionz/backend/chat/chat_room/ChatRoomService.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_room/ChatRoomService.java
@@ -56,7 +56,7 @@ public class ChatRoomService {
 
         // 채팅방 생성
         ChatRoom chatRoom = createChatRoom(chatRoomName);
-        BaseResponse<Void> participantResponse = saveChatParticipants(chatRoom, request.getParticipants());
+        BaseResponse<BaseResponseStatus> participantResponse = saveChatParticipants(chatRoom, request.getParticipants());
         if (!participantResponse.getSuccess()) {
             return new BaseResponse<>(BaseResponseStatus.CHATROOM_CREATE_FAIL);
         }
@@ -72,7 +72,7 @@ public class ChatRoomService {
     }
 
     // 채팅룸 리스트 조회
-    public List<ReadChatRoomResponse> roomList(Long userId) {
+    public List<ReadChatRoomResponse> roomList(Long userId, Long workspaceId) {
         List<ChatParticipation> chatParticipations = chatParticipationRepository.findByUser_UserId(userId);
 
         List<ReadChatRoomResponse> responseList = new ArrayList<>();
@@ -88,6 +88,7 @@ public class ChatRoomService {
                     chatRoom.getChatRoomId(), userId, MessageStatus.UNREAD);
 
             ReadChatRoomResponse response = ReadChatRoomResponse.builder()
+                    .workspaceId(workspaceId)
                     .chatroomId(chatRoom.getChatRoomId())
                     .chatRoomName(chatRoom.getChatRoomName())
                     .messageContents(latestMessage != null ? latestMessage.getMessageContents() : "채팅방에 메세지가 없습니다.")
@@ -107,7 +108,7 @@ public class ChatRoomService {
         return chatRoomRepository.save(chatRoom);
     }
 
-    private BaseResponse<Void> saveChatParticipants(ChatRoom chatRoom, List<Long> participantIds) {
+    private BaseResponse<BaseResponseStatus> saveChatParticipants(ChatRoom chatRoom, List<Long> participantIds) {
         for (Long participantId : participantIds) {
             User participant = userRepository.findById(participantId)
                     .orElse(null); // User가 null인 경우를 처리하기 위해

--- a/backend/src/main/java/minionz/backend/chat/chat_room/model/response/ReadChatRoomResponse.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_room/model/response/ReadChatRoomResponse.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 @Getter
 public class ReadChatRoomResponse {
     private Long chatroomId;
+    private Long workspaceId;
     private String chatRoomName;
     private String messageContents;
     private LocalDateTime createdAt;

--- a/backend/src/main/java/minionz/backend/chat/message/MessageController.java
+++ b/backend/src/main/java/minionz/backend/chat/message/MessageController.java
@@ -51,11 +51,19 @@ public class MessageController {
         return new BaseResponse<>(BaseResponseStatus.CHAT_HISTORY_RETRIEVAL_SUCCESS, response);
     }
 
+    // 메세지 수정
     @MessageMapping("/room/{chatRoomId}/edit")
     public void updateMessage(@Payload UpdateMessageRequest request, @AuthenticationPrincipal CustomSecurityUserDetails customUserDetails) {
         Long senderId = customUserDetails.getUser().getUserId();
         messageService.updateMessage(request.getChatRoomId(), request, senderId);
     }
 
+    // 메세지 삭제
+    @DeleteMapping("/message/{messageId}")
+    public BaseResponse<BaseResponseStatus> deleteMessage(@PathVariable Long messageId, @AuthenticationPrincipal CustomSecurityUserDetails customUserDetails) {
+        Long senderId = customUserDetails.getUser().getUserId();
+        messageService.deleteMessage(messageId, senderId);
+        return new BaseResponse<>(BaseResponseStatus.MESSAGE_DELETE_SUCCESS);
+    }
 }
 

--- a/backend/src/main/java/minionz/backend/chat/message/MessageRepository.java
+++ b/backend/src/main/java/minionz/backend/chat/message/MessageRepository.java
@@ -30,7 +30,8 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
             "ORDER BY m.createdAt DESC")
     List<Message> findLatestMessagesByChatRoomId(Long chatRoomId);
 
-    List<Message> findByChatParticipation_ChatRoom_ChatRoomIdOrderByCreatedAtAsc(Long chatRoomId);
+    @Query("SELECT m FROM Message m WHERE m.chatParticipation.chatRoom.chatRoomId = :chatRoomId AND m.deletedAt IS NULL ORDER BY m.createdAt ASC")
+    List<Message> findByChatRoomIdAndDeletedAtIsNullOrderByCreatedAtAsc(Long chatRoomId);
 
     @Query("SELECT m FROM Message m WHERE m.messageId = :messageId")
     Message findMessageById(Long messageId);

--- a/backend/src/main/java/minionz/backend/common/responses/BaseResponseStatus.java
+++ b/backend/src/main/java/minionz/backend/common/responses/BaseResponseStatus.java
@@ -80,16 +80,21 @@ public enum BaseResponseStatus {
 
     CHATROOM_CREATE_SUCCESS(true, 6001, "채팅방 생성에 성공했습니다."),
     CHATROOM_CREATE_FAIL(false, 6002, "채팅방 생성에 실패했습니다."),
+
     CHATROOM_LIST_SUCCESS(true, 6101, "채팅방 조회에 성공했습니다."),
     CHATROOM_LIST_FAIL(false, 6102, "채팅방 조회에 실패했습니다."),
+
     MESSAGE_SEND_SUCCESS(true, 6201, "메세지가 성공적으로 전송되었습니다."),
     MESSAGE_SEND_FAIL(false, 6202, "메세지가 전송되지 않았습니다."),
+
     CHAT_PARTICIPATION_NOT_FOUND(false, 6203, "참여자가 존재하지 않습니다."),
     CHAT_HISTORY_RETRIEVAL_SUCCESS(true, 6301, "채팅 내역 조회에 성공했습니다."),
     CHAT_ROOM_NOT_FOUND(false, 6302, "해당 채팅방을 찾을 수 없습니다."),
     MESSAGE_HISTORY_NOT_FOUND(false, 6303, "해당 채팅방에 메시지 내역이 없습니다."),
     UNAUTHORIZED_CHAT_ACCESS(false, 6304, "해당 채팅방에 접근할 권한이 없습니다."),
-    FAILED_TO_RETRIEVE_CHAT_HISTORY(false, 6305, "채팅 내역 조회에 실패했습니다.");
+    FAILED_TO_RETRIEVE_CHAT_HISTORY(false, 6305, "채팅 내역 조회에 실패했습니다."),
+
+    MESSAGE_DELETE_SUCCESS(true, 6401, "메세지가 성공적으로 삭제되었습니다.");
 
 
 


### PR DESCRIPTION
## 연관된 이슈
#2 , #27 
<br>

## 작업 내용
- 채팅 삭제 기능을 구현 했습니다. 
  - 물리적으로 삭제하지 않고, 논리적으로 삭제하게 했습니다.  삭제 여부를 나타내는 deletedAt 를 사용하여 데이터가 삭제 되었음을 표시 했습니다.
  - 이 과정에서 채팅 내역을 불러올 때 삭제 내역까지 불러오지 않게 deletedAt의 null 인 채팅 내역만 받아올 수 있도록 이 부분을 수정 했습니다.
- 채팅방 내역을 받아올 때 채팅방이 워크스페이스 내에 존재함을 인지하고 URL 주소를 변경하게 됐습니다. 
  -  채팅방 조회를 할 때 workspaceId를 response값으로도 받을 수 있게 수정 했습니다.
- 채팅 삭제 관련 부분에 BaseResponse 상태를 추가 했습니다.
<br> 

## 전달 사항
close #27
