### PR TITLE
[Feat] CHAT_004 - 채팅방 수정 기능 구현 [#18]

### DIFF
--- a/backend/src/main/java/minionz/backend/chat/chat_participation/ChatParticipationRepository.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_participation/ChatParticipationRepository.java
@@ -10,5 +10,6 @@ public interface ChatParticipationRepository extends JpaRepository<ChatParticipa
     List<ChatParticipation> findByUser_UserId(Long userId);
     List<ChatParticipation> findAllByUser_UserId(Long userId);
     ChatParticipation findByChatRoom_ChatRoomIdAndUser_UserId(Long chatRoomId, Long userId);
+    boolean existsByChatRoom_ChatRoomIdAndUser_UserId(Long chatRoomId, Long userId);
 }
 

--- a/backend/src/main/java/minionz/backend/chat/chat_room/ChatRoomController.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_room/ChatRoomController.java
@@ -2,6 +2,7 @@ package minionz.backend.chat.chat_room;
 
 import lombok.RequiredArgsConstructor;
 import minionz.backend.chat.chat_room.model.request.CreateChatRoomRequest;
+import minionz.backend.chat.chat_room.model.request.UpdateChatRoomRequest;
 import minionz.backend.chat.chat_room.model.response.CreateChatRoomResponse;
 import minionz.backend.chat.chat_room.model.response.ReadChatRoomResponse;
 import minionz.backend.common.responses.BaseResponse;
@@ -31,5 +32,12 @@ public class ChatRoomController {
         User user = customUserDetails.getUser();
         List<ReadChatRoomResponse> response = chatRoomService.roomList(user.getUserId(), workspaceId);
         return new BaseResponse<>(BaseResponseStatus.CHATROOM_LIST_SUCCESS, response);
+    }
+
+    @PatchMapping(value = "/room/{chatRoomId}/edit")
+    public BaseResponse<BaseResponseStatus> updateRoomName(@PathVariable Long chatRoomId, @RequestBody UpdateChatRoomRequest request, @AuthenticationPrincipal CustomSecurityUserDetails customUserDetails) {
+        User user = customUserDetails.getUser();
+        BaseResponse<BaseResponseStatus> response = chatRoomService.updateChatRoomName(chatRoomId, request, user);
+        return response;
     }
 }

--- a/backend/src/main/java/minionz/backend/chat/chat_room/ChatRoomService.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_room/ChatRoomService.java
@@ -5,6 +5,7 @@ import minionz.backend.chat.chat_participation.ChatParticipationRepository;
 import minionz.backend.chat.chat_participation.model.ChatParticipation;
 import minionz.backend.chat.chat_room.model.ChatRoom;
 import minionz.backend.chat.chat_room.model.request.CreateChatRoomRequest;
+import minionz.backend.chat.chat_room.model.request.UpdateChatRoomRequest;
 import minionz.backend.chat.chat_room.model.response.CreateChatRoomResponse;
 import minionz.backend.chat.chat_room.model.response.ReadChatRoomResponse;
 import minionz.backend.chat.message.MessageRepository;
@@ -99,6 +100,25 @@ public class ChatRoomService {
             responseList.add(response);
         }
         return responseList;
+    }
+
+    public BaseResponse<BaseResponseStatus> updateChatRoomName(Long chatRoomId, UpdateChatRoomRequest request, User user) {
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId).orElse(null);
+
+        // 채팅방이 존재하지 않는 경우
+        if (chatRoom == null) {
+            return new BaseResponse<>(BaseResponseStatus.CHAT_ROOM_NOT_FOUND);
+        }
+
+        boolean isParticipant = chatParticipationRepository.existsByChatRoom_ChatRoomIdAndUser_UserId(chatRoomId, user.getUserId());
+        if (!isParticipant) {
+            return new BaseResponse<>(BaseResponseStatus.CHATROOM_USER_NOT_AUTHORIZED);
+        }
+
+        chatRoom.setChatRoomName(request.getNewChatRoomName());
+        chatRoomRepository.save(chatRoom);
+
+        return new BaseResponse<>(BaseResponseStatus.CHATROOM_UPDATE_SUCCESS);
     }
 
     private ChatRoom createChatRoom(String chatRoomName) {

--- a/backend/src/main/java/minionz/backend/chat/chat_room/model/request/UpdateChatRoomRequest.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_room/model/request/UpdateChatRoomRequest.java
@@ -1,0 +1,14 @@
+package minionz.backend.chat.chat_room.model.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateChatRoomRequest {
+    private String newChatRoomName;
+}

--- a/backend/src/main/java/minionz/backend/common/responses/BaseResponseStatus.java
+++ b/backend/src/main/java/minionz/backend/common/responses/BaseResponseStatus.java
@@ -93,8 +93,11 @@ public enum BaseResponseStatus {
     MESSAGE_HISTORY_NOT_FOUND(false, 6303, "해당 채팅방에 메시지 내역이 없습니다."),
     UNAUTHORIZED_CHAT_ACCESS(false, 6304, "해당 채팅방에 접근할 권한이 없습니다."),
     FAILED_TO_RETRIEVE_CHAT_HISTORY(false, 6305, "채팅 내역 조회에 실패했습니다."),
+    CHATROOM_UPDATE_SUCCESS(true, 6401, "채팅방 수정이 완료 되었습니다."),
+    CHATROOM_NOT_FOUND(false, 6402, "해당 채팅방이 존재하지 않습니다."),
+    CHATROOM_USER_NOT_AUTHORIZED(false, 6403, "해당 참가자는 채팅방에 존재하지 않습니다."),
 
-    MESSAGE_DELETE_SUCCESS(true, 6401, "메세지가 성공적으로 삭제되었습니다.");
+    MESSAGE_DELETE_SUCCESS(true, 6501, "메세지가 성공적으로 삭제되었습니다.");
 
 
 


### PR DESCRIPTION
## 연관된 이슈
#18 
<br>

## 작업 내용
- 채팅방 이름을 수정할 수 있게 구현 했습니다.
  - 해당 채팅방이 존재하는지 확인 하고, 채팅방에 참가 중인 유저인지 확인 후에 변경할 수 있도록 구현 했습니다. 
- 채팅방 관련 상태를 추가 했습니다. 추후에 더 추가 될 예정입니다.

<br> 

## 전달 사항
close #18 

전체적인 채팅방 이름이 변경 돼서 채팅방을 만든 사람만 변경을 해야할지, 변경에는 자유롭게 할지 고민 중입니다. 의견 있으신 분들은 말씀 해 주시면 감사합니다. 
