### PR TITLE
[Feat] CHAT_002 - 채팅방 나가기 기능 구현 [#8]

### DIFF
--- a/backend/src/main/java/minionz/backend/chat/chat_participation/ChatParticipationRepository.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_participation/ChatParticipationRepository.java
@@ -2,14 +2,19 @@ package minionz.backend.chat.chat_participation;
 
 import minionz.backend.chat.chat_participation.model.ChatParticipation;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface ChatParticipationRepository extends JpaRepository<ChatParticipation, Long> {
     List<ChatParticipation> findByUser_UserId(Long userId);
+    List<ChatParticipation> findByUser_UserIdAndIsActiveTrue(Long userId);
     List<ChatParticipation> findAllByUser_UserId(Long userId);
     ChatParticipation findByChatRoom_ChatRoomIdAndUser_UserId(Long chatRoomId, Long userId);
     boolean existsByChatRoom_ChatRoomIdAndUser_UserId(Long chatRoomId, Long userId);
+
+    @Query("SELECT cp FROM ChatParticipation cp WHERE cp.chatRoom.chatRoomId = :chatRoomId AND cp.user.userId = :userId")
+    ChatParticipation findByChatRoom_ChatRoomIdAndUser_UserId2(Long chatRoomId, Long userId);
 }
 

--- a/backend/src/main/java/minionz/backend/chat/chat_participation/model/ChatParticipation.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_participation/model/ChatParticipation.java
@@ -34,4 +34,8 @@ public class ChatParticipation {
     @JoinColumn(name = "chat_room_id")
     private ChatRoom chatRoom;
 
+    // 사용자가 참여 중인 상태
+    @Column(nullable = false)
+    private boolean isActive = true;
+
 }

--- a/backend/src/main/java/minionz/backend/chat/chat_room/ChatRoomController.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_room/ChatRoomController.java
@@ -40,4 +40,12 @@ public class ChatRoomController {
         BaseResponse<BaseResponseStatus> response = chatRoomService.updateChatRoomName(chatRoomId, request, user);
         return response;
     }
+
+    @DeleteMapping("/{chatRoomId}/exit")
+    public BaseResponse<BaseResponseStatus> exitChatRoom(@AuthenticationPrincipal CustomSecurityUserDetails customUserDetails,
+                                             @PathVariable Long chatRoomId) {
+        User user = customUserDetails.getUser();
+        BaseResponse<BaseResponseStatus> response = chatRoomService.exitChatRoom(chatRoomId, user);
+        return response;
+    }
 }

--- a/backend/src/main/java/minionz/backend/common/responses/BaseResponseStatus.java
+++ b/backend/src/main/java/minionz/backend/common/responses/BaseResponseStatus.java
@@ -97,7 +97,10 @@ public enum BaseResponseStatus {
     CHATROOM_NOT_FOUND(false, 6402, "해당 채팅방이 존재하지 않습니다."),
     CHATROOM_USER_NOT_AUTHORIZED(false, 6403, "해당 참가자는 채팅방에 존재하지 않습니다."),
 
-    MESSAGE_DELETE_SUCCESS(true, 6501, "메세지가 성공적으로 삭제되었습니다.");
+    MESSAGE_DELETE_SUCCESS(true, 6501, "메세지가 성공적으로 삭제되었습니다."),
+
+    CHATROOM_EXIT_SUCCESS(true, 6601, "채팅방에서 성공적으로 나갔습니다."),
+    CHATROOM_EXIT_FAIL(false, 6602, "채팅방 나가기에 실패했습니다.");
 
 
 


### PR DESCRIPTION
## 연관된 이슈
#8
<br>

## 작업 내용
- 채팅방 나가기 기능을 구현 했습니다.
  - 채팅방을 나가게 되면 해당 채팅방이 삭제 되지 않고, 유지되며 나간 해당 사용자만 채팅방을 조회 했을 때 뜨지 않게 했습니다.
  - 채팅참여 엔티티에 isActive 라는 사용자가 참여 중인 상태를 볼 수 있게 추가하였습니다.
    - 채팅방을 생성 했을 때 자동으로 사용자들은 true라는 값을 갖게 되고, 채팅방을 조회 할 때  isActive가 true인 방만 (참여 중인) 나오도록 했습니다.
    - 채팅방 나가기를 눌렀을 시에 isActive가 false으로 바뀌며, 조회가 불가능하게 해 뒀습니다.
- baseResponse 상태값에 채팅방 나가기에 대한 코드들을 추가 해 뒀습니다.
<br> 

## 전달 사항
close #8 
