### PR TITLE
[Feat] CHAT_012 - 메세지 상태 값 변경 기능 [#181]

### DIFF
--- a/backend/src/main/java/minionz/backend/chat/message/MessageController.java
+++ b/backend/src/main/java/minionz/backend/chat/message/MessageController.java
@@ -65,5 +65,13 @@ public class MessageController {
         messageService.deleteMessage(messageId, senderId);
         return new BaseResponse<>(BaseResponseStatus.MESSAGE_DELETE_SUCCESS);
     }
+
+    // 상태 업데이트
+    @GetMapping("/enter/{chatRoomId}")
+    public BaseResponse<BaseResponseStatus> enterChatRoom(@PathVariable Long chatRoomId, @AuthenticationPrincipal CustomSecurityUserDetails userDetails) {
+        Long userId = userDetails.getUser().getUserId();
+        messageService.enterChatRoom(chatRoomId, userId);
+        return new BaseResponse<>(BaseResponseStatus.MESSAGE_STATUS_UPDATE_SUCCESS);
+    }
 }
 

--- a/backend/src/main/java/minionz/backend/chat/message/MessageRepository.java
+++ b/backend/src/main/java/minionz/backend/chat/message/MessageRepository.java
@@ -36,6 +36,12 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
     @Query("SELECT m FROM Message m WHERE m.messageId = :messageId")
     Message findMessageById(Long messageId);
 
+    @Query("SELECT m FROM Message m " +
+            "WHERE m.chatRoomId = :chatRoomId " +
+            "AND m.messageStatus = :status")
+    List<Message> findUnreadMessagesByChatRoomId(Long chatRoomId, MessageStatus status);
+
+
 
 
 }

--- a/backend/src/main/java/minionz/backend/chat/message/MessageService.java
+++ b/backend/src/main/java/minionz/backend/chat/message/MessageService.java
@@ -129,6 +129,14 @@ public class MessageService {
                 .collect(Collectors.toList());
     }
 
+    public void enterChatRoom(Long chatRoomId, Long userId) {
+        List<Message> unreadMessages = messageRepository.findUnreadMessagesByChatRoomId(chatRoomId, MessageStatus.UNREAD);
+        for (Message message : unreadMessages) {
+            message.setMessageStatus(MessageStatus.READ);
+        }
+        messageRepository.saveAll(unreadMessages);
+    }
+
     @KafkaListener(topicPattern = "chat-room-.*", groupId = "${spring.kafka.consumer.group-id}")
     public void consumeMessage(ConsumerRecord<String, String> record) {
         try {

--- a/backend/src/main/java/minionz/backend/common/responses/BaseResponseStatus.java
+++ b/backend/src/main/java/minionz/backend/common/responses/BaseResponseStatus.java
@@ -100,7 +100,10 @@ public enum BaseResponseStatus {
     MESSAGE_DELETE_SUCCESS(true, 6501, "메세지가 성공적으로 삭제되었습니다."),
 
     CHATROOM_EXIT_SUCCESS(true, 6601, "채팅방에서 성공적으로 나갔습니다."),
-    CHATROOM_EXIT_FAIL(false, 6602, "채팅방 나가기에 실패했습니다.");
+    CHATROOM_EXIT_FAIL(false, 6602, "채팅방 나가기에 실패했습니다."),
+
+    MESSAGE_STATUS_UPDATE_SUCCESS(true, 6701, "메세지 상태 변경이 성공적으로 완료되었습니다."),
+    MESSAGE_STATUS_UPDATE_FAIL(false, 6702, "상태 변경에 실패했습니다.");
 
 
 


### PR DESCRIPTION
## 연관된 이슈
#181 
<br>

## 작업 내용
- 메세지를 전송하면 기본적으로 UNREAD 처리되게 해 두었습니다.
  - 채팅방에 들어가기 전까지는 채팅방을 조회 할 때 unreadMessages에 개수가 쌓이고 있었는데, 해당 api를 호출하게 되면 unread의 메세지들의 상태가 전부 read로 변하도록 했습니다.
- 메세지 상태 값 변경에 대한 response status도 추가 해 뒀습니다.
<br> 

## 전달 사항
close #181 
