### PR TITLE
[Feat] CHAT_010 - 채팅 대상 검색 기능 구현 [#31]

### DIFF
--- a/backend/src/main/java/minionz/backend/chat/chat_room/ChatRoomController.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_room/ChatRoomController.java
@@ -2,9 +2,11 @@ package minionz.backend.chat.chat_room;
 
 import lombok.RequiredArgsConstructor;
 import minionz.backend.chat.chat_room.model.request.CreateChatRoomRequest;
+import minionz.backend.chat.chat_room.model.request.SearchChatRoomRequest;
 import minionz.backend.chat.chat_room.model.request.UpdateChatRoomRequest;
 import minionz.backend.chat.chat_room.model.response.CreateChatRoomResponse;
 import minionz.backend.chat.chat_room.model.response.ReadChatRoomResponse;
+import minionz.backend.chat.chat_room.model.response.SearchChatRoomResponse;
 import minionz.backend.common.responses.BaseResponse;
 import minionz.backend.common.responses.BaseResponseStatus;
 import minionz.backend.user.model.CustomSecurityUserDetails;
@@ -48,4 +50,12 @@ public class ChatRoomController {
         BaseResponse<BaseResponseStatus> response = chatRoomService.exitChatRoom(chatRoomId, user);
         return response;
     }
+
+    @GetMapping("/search")
+    public BaseResponse<List<SearchChatRoomResponse>> searchChatRooms(@RequestBody SearchChatRoomRequest request) {
+        List<SearchChatRoomResponse> response = chatRoomService.searchRoomList(request);
+        return new BaseResponse<>(BaseResponseStatus.CHATROOM_SEARCH_SUCCESS, response);
+    }
+
+
 }

--- a/backend/src/main/java/minionz/backend/chat/chat_room/ChatRoomRepository.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_room/ChatRoomRepository.java
@@ -2,6 +2,12 @@ package minionz.backend.chat.chat_room;
 
 import minionz.backend.chat.chat_room.model.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+    @Query("SELECT c FROM ChatRoom c WHERE LOWER(c.chatRoomName) LIKE LOWER(CONCAT('%', :chatRoomName, '%'))")
+    List<ChatRoom> findByChatRoomNameContainingIgnoreCase(String chatRoomName);
 }

--- a/backend/src/main/java/minionz/backend/chat/chat_room/ChatRoomService.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_room/ChatRoomService.java
@@ -5,9 +5,11 @@ import minionz.backend.chat.chat_participation.ChatParticipationRepository;
 import minionz.backend.chat.chat_participation.model.ChatParticipation;
 import minionz.backend.chat.chat_room.model.ChatRoom;
 import minionz.backend.chat.chat_room.model.request.CreateChatRoomRequest;
+import minionz.backend.chat.chat_room.model.request.SearchChatRoomRequest;
 import minionz.backend.chat.chat_room.model.request.UpdateChatRoomRequest;
 import minionz.backend.chat.chat_room.model.response.CreateChatRoomResponse;
 import minionz.backend.chat.chat_room.model.response.ReadChatRoomResponse;
+import minionz.backend.chat.chat_room.model.response.SearchChatRoomResponse;
 import minionz.backend.chat.message.MessageRepository;
 import minionz.backend.chat.message.model.Message;
 import minionz.backend.chat.message.model.MessageStatus;
@@ -24,6 +26,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -141,7 +144,31 @@ public class ChatRoomService {
         return new BaseResponse<>(BaseResponseStatus.CHATROOM_EXIT_SUCCESS);
     }
 
+    public List<SearchChatRoomResponse> searchRoomList(SearchChatRoomRequest request) {
+        String chatRoomName = request.getChatRoomName();
+        List<ChatRoom> chatRooms = chatRoomRepository.findByChatRoomNameContainingIgnoreCase(chatRoomName);
 
+        return chatRooms.stream().map(chatRoom -> {
+            Message latestMessage = findLatestMessage(chatRoom.getChatRoomId());
+            Long unreadMessagesCount = messageRepository.countUnreadMessagesByChatRoomIdAndUserId(chatRoom.getChatRoomId(), null, MessageStatus.UNREAD);
+            // 마지막 메세지가 파일인 경우에는 null 값을 방지
+            String messageContents = "채팅방에 메세지가 없습니다.";
+            if (latestMessage != null) {
+                if (latestMessage.getFileUrl() != null) {
+                    messageContents = "파일이 전송되었습니다.";
+                } else {
+                    messageContents = latestMessage.getMessageContents();
+                }
+            }
+            return SearchChatRoomResponse.builder()
+                    .chatroomId(chatRoom.getChatRoomId())
+                    .chatRoomName(chatRoom.getChatRoomName())
+                    .messageContents(messageContents)
+                    .createdAt(latestMessage != null ? latestMessage.getCreatedAt() : chatRoom.getCreatedAt())
+                    .UnreadMessages(unreadMessagesCount != null ? unreadMessagesCount.intValue() : 0)
+                    .build();
+        }).collect(Collectors.toList());
+    }
 
     private ChatRoom createChatRoom(String chatRoomName) {
         ChatRoom chatRoom = ChatRoom.builder()

--- a/backend/src/main/java/minionz/backend/chat/chat_room/model/request/SearchChatRoomRequest.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_room/model/request/SearchChatRoomRequest.java
@@ -1,0 +1,14 @@
+package minionz.backend.chat.chat_room.model.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SearchChatRoomRequest {
+    private String chatRoomName;
+}

--- a/backend/src/main/java/minionz/backend/chat/chat_room/model/response/SearchChatRoomResponse.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_room/model/response/SearchChatRoomResponse.java
@@ -1,0 +1,16 @@
+package minionz.backend.chat.chat_room.model.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+public class SearchChatRoomResponse {
+    private Long chatroomId;
+    private String chatRoomName;
+    private String messageContents;
+    private LocalDateTime createdAt;
+    private Integer UnreadMessages;
+}

--- a/backend/src/main/java/minionz/backend/common/responses/BaseResponseStatus.java
+++ b/backend/src/main/java/minionz/backend/common/responses/BaseResponseStatus.java
@@ -103,7 +103,9 @@ public enum BaseResponseStatus {
     CHATROOM_EXIT_FAIL(false, 6602, "채팅방 나가기에 실패했습니다."),
 
     MESSAGE_STATUS_UPDATE_SUCCESS(true, 6701, "메세지 상태 변경이 성공적으로 완료되었습니다."),
-    MESSAGE_STATUS_UPDATE_FAIL(false, 6702, "상태 변경에 실패했습니다.");
+    MESSAGE_STATUS_UPDATE_FAIL(false, 6702, "상태 변경에 실패했습니다."),
+
+    CHATROOM_SEARCH_SUCCESS(true, 6801, "채팅방 검색에 성공했습니다.");
 
 
 


### PR DESCRIPTION
## 연관된 이슈
#31 
<br>

## 작업 내용
- 채팅방 내에서 검색 할 수 있는 기능을 구현 했습니다.
  - 채팅방을 검색 할 때 마지막 메세지가 파일이면 메세지를 불러오지 못하는 오류를 발견 했습니다.
    - url을 불러올까 고민하다 결국 마지막 메세지가 파일 형식이라면,  "파일이 전송되었습니다." 라는 값을 마지막 메세지에 넣도록 설정 했습니다.
- 채팅방 검색에 대한 상태 값을 추가 했습니다.
<br> 

## 전달 사항
close #31 
