### PR TITLE
[Feat] FE_ERR_BOARD001,002,003 Error create, list, detail 페이지

### DIFF
--- a/frontend/src/layouts/component/WorkSpaceMenu.vue
+++ b/frontend/src/layouts/component/WorkSpaceMenu.vue
@@ -1,37 +1,34 @@
 <script setup>
 import { useRoute } from 'vue-router';
-import {computed} from "vue";
-import {workspaceData} from "@/static/workspaceData";
 // import { workspaceData } from "@/static/workspaceData";
 // import { computed } from "vue";
 
 const route = useRoute();
 const workspaceId = route.params.workspaceId;
-const workspace = computed(() => workspaceData.find(ws => ws.workspaceId === workspaceId));
 </script>
 
 <template>
   <ul>
     <li>
-      <router-link :to="`/workspace/${workspace}/dashboard`">
+      <router-link :to="`/workspace/${workspaceId}/dashboard`">
         <i class="icon-dashboard"/>
         <p class="outfit">Dashboard</p>
       </router-link>
     </li>
     <li>
-      <router-link :to="`/workspace/${workspace}/monthly`">
+      <router-link :to="`/workspace/${workspaceId}/monthly`">
         <i class="icon-schedule"/>
         <p class="outfit">Schedule</p>
       </router-link>
     </li>
     <li>
-      <router-link :to="`/workspace/${workspace}/scrum/board/qa/list`">
+      <router-link :to="`/workspace/${workspaceId}/scrum/board/qa/list`">
         <i class="icon-board"/>
         <p class="outfit">Board</p>
       </router-link>
       <ul class="submenu">
         <li>
-          <router-link :to="`/workspace/${workspace}/scrum/board/qa/list`">
+          <router-link :to="`/workspace/${workspaceId}/scrum/board/qa/list`">
             <i class="icon-qa"/>
             <p class="outfit">QA Board</p>
           </router-link>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -216,7 +216,7 @@ const routes = [
                                         component: () => import('@/view/board/list/ErrorList.vue')
                                     },
                                     {
-                                        path: 'detail',
+                                        path: 'detail/:id',
                                         name: 'ErrorDetail',
                                         component: () => import('@/view/board/detail/ErrorDetail.vue')
                                     },

--- a/frontend/src/static/errorListData.js
+++ b/frontend/src/static/errorListData.js
@@ -1,0 +1,11 @@
+export const errorListData =[
+    {
+        title: '게시판 제목 1', author: 'seung-eun', language: 'Java', date: 'May 5, 2020'
+    },
+    {
+        title: '게시판 제목 2', author: 'seung-eun1', language: 'Vue', date: 'May 5, 2020'
+    },
+    {
+        title: '게시판 제목 3', author: 'seung-eun2', language: 'SQL', date: 'May 5, 2020'
+    },
+];

--- a/frontend/src/view/board/create/ErrorCreate.vue
+++ b/frontend/src/view/board/create/ErrorCreate.vue
@@ -1,13 +1,131 @@
 <script setup>
+import {inject} from "vue";
+import QuillEditor from "@/common/component/Editor/QuillEditor.vue";
 
+const contentsTitle = inject('contentsTitle');
+const contentsDescription = inject('contentsDescription');
+
+contentsTitle.value = 'Error 게시글 쓰기';
+contentsDescription.value = 'Error 게시글을 만들어 보세요!';
 </script>
 
 <template>
-  <div>
-    <h1>ErrorCreate</h1>
+  <div class="error-detail-container">
+    <div class="error-note-container">
+      <div class="error-input-wrap">
+        <div class="error-title-container">
+        <span class="column">
+          <i class="error-title column-icon"></i>
+          게시글 제목
+        </span>
+          <input  class="title-editor" placeholder="게시글 제목" />
+        </div>
+        <!--      설명 추가하기-->
+        <div class="language-section">
+        <span class="column">
+          <i class="languages column-icon"></i>
+          설명 추가하기
+        </span>
+          <input class="language-editor" placeholder="언어" />
+        </div>
+        <QuillEditor/>
+      </div>
+    </div>
+    <button class="save-button">저장하기</button>
   </div>
 </template>
 
 <style scoped>
+.error-detail-container{
+  padding: 30px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+  height: 100%;
+  justify-content: space-between;
+  box-sizing: border-box;
+}
 
+.error-note-container {
+  //padding: 30px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+  height: 100%;
+  justify-content: space-between;
+  box-sizing: border-box;
+  //height: 100%;
+  //overflow-y: auto;
+  //display: flex;
+  //flex-direction: column-reverse;
+}
+
+.error-input-wrap{
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.error-title-container{
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.error-title{
+  background-image: url("@/assets/icon/boardIcon/quillEditor.svg");
+  width: 24px;
+  height: 24px;
+  margin-right: 5px;
+}
+
+.title-editor {
+  width: 100%;
+  height: 2rem;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  padding: 0 10px;
+}
+
+.column{
+  display: flex;
+  align-items: center;
+  width: 10rem;
+  gap: 10px;
+}
+
+.languages{
+  background-image: url("@/assets/icon/boardIcon/quillDescription.svg");
+  width: 24px;
+  height: 24px;
+  margin-right: 5px;
+}
+
+.language-section{
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.language-editor {
+  width: 100%;
+  height: 2rem;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  padding: 0 10px;
+}
+
+.save-button {
+  background-color: #e0e8ff;
+  color: #666daf;
+  padding: 10px 20px;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  //margin-top: 20px;
+  width: 150px;
+  margin-left: auto;
+}
 </style>

--- a/frontend/src/view/board/detail/ErrorDetail.vue
+++ b/frontend/src/view/board/detail/ErrorDetail.vue
@@ -1,13 +1,37 @@
 <script setup>
+import BoardDetail from "@/view/board/component/BoardDetail.vue";
+import {inject} from "vue";
+import DateComment from "@/view/board/component/DateComment.vue";
 
+const contentsTitle = inject('contentsTitle');
+const contentsDescription = inject('contentsDescription');
+
+contentsTitle.value = 'Error 상세 보기';
+contentsDescription.value = 'Error를 확인하세요!';
 </script>
 
 <template>
-  <div>
-    <h1>ErrorCreate</h1>
+  <div class="error-detail-container">
+    <BoardDetail
+        title="프론트엔드 오류"
+        language="JavaScript"
+        subheading="필터링 후 선택 기능 오류"
+        :descriptionList="[
+      '사용자가 검색할 때, 필터를 통해 검색한 내용을 거른 후 검색할 수 있어야 합니다.',
+      '셀렉트 박스를 통해 필터를 누르고 나면, 하위 아이템들이 필터 된 것들로 제공되어야 합니다.'
+    ]"
+        owner="최승은"
+    />
+    <DateComment
+        date="Aug 19, 2021"
+        :comments="3"
+    />
   </div>
+
 </template>
 
 <style scoped>
-
+.error-detail-container{
+  padding: 30px;
+}
 </style>

--- a/frontend/src/view/board/list/ErrorList.vue
+++ b/frontend/src/view/board/list/ErrorList.vue
@@ -1,10 +1,65 @@
 <script setup>
+import {computed, inject, ref} from 'vue';
+import { errorListData } from "@/static/errorListData";
+import { workspaceData } from "@/static/workspaceData";
+import Pagination from '@/common/component/PaginationComponent.vue';
+import BoardList from "@/view/board/component/BoardList.vue";
+import SearchComponent from "@/common/component/SearchComponent.vue";
+import {useRoute} from "vue-router";
 
+const route = useRoute();
+const workspaceId = route.params.workspaceId;
+const workspace = computed(() => workspaceData.find(ws => ws.workspaceId === workspaceId));
+
+const contentsTitle = inject('contentsTitle');
+const contentsDescription = inject('contentsDescription');
+
+contentsTitle.value = workspace.value ? `${workspace.value.workspaceName} Error Board List` : 'Error Board List';
+contentsDescription.value = 'Error 목록을 확인하세요!';
+
+const currentPage = ref(1);
+const itemsPerPage = 10;
+
+const totalPages = computed(() => Math.ceil((errorListData.value?.length || 0) / itemsPerPage));
+
+const prevPage = () => {
+  if (currentPage.value > 1) {
+    currentPage.value--;
+  }
+};
+
+const nextPage = () => {
+  if (currentPage.value < totalPages.value) {
+    currentPage.value++;
+  }
+};
+
+const goToPage = (page) => {
+  currentPage.value = page;
+};
+
+const editItem = (item) => {
+  console.log('Editing:', item);
+};
+
+const deleteItem = (item) => {
+  console.log('Deleting:', item);
+};
 </script>
 
 <template>
-  <div>
-    <h1>ErrorList</h1>
+  <div class="board-list-container">
+    <div class="header">
+      <SearchComponent :link="`/workspace/${workspaceId}/scrum/board/error/create`" />
+    </div>
+    <BoardList :items="errorListData" thcolumn="언어" column="language" board-type="error" @edit-item="editItem" @delete-item="deleteItem" />
+    <Pagination
+        :currentPage="currentPage"
+        :totalPages="totalPages"
+        @prev-page="prevPage"
+        @next-page="nextPage"
+        @go-to-page="goToPage"
+    />
   </div>
 </template>
 


### PR DESCRIPTION
## 연관된 이슈
<!-- 관련된 이슈 번호를 적어주세요 -->
#62 #63 #64
<br>

## 작업 내용
<!-- 작업에 대한 설명을 적어주세요 -->
- error 게시판에 대한 리스트 페이지 ui 마크업을 완성했습니다. 테이블 형태로 구현 됐으며 현재 더미 데이터가 들어가 있습니다.
- error 게시판에 대한 상세 조회 페이지 ui 마크업을 완성했습니다.
- error 게시판에 대한 생성 페이지 ui 마크업을 완성했습니다. quill을 이용한 게시글의 속성과 글이 추가 가능합니다.
<br> 

## 전달 사항
<!-- 참고할 사항이 있다면 알려주세요 -->
댓글 구현 미완료 입니다.