### PR TITLE
[Refactor] CHAT_003,005 - 메세지 전송 DTO 변경 및 cors 처리 [#11, #20]

### DIFF
--- a/backend/src/main/java/minionz/backend/chat/chat_room/ChatRoomService.java
+++ b/backend/src/main/java/minionz/backend/chat/chat_room/ChatRoomService.java
@@ -92,11 +92,20 @@ public class ChatRoomService {
             Long unreadMessagesCount = messageRepository.countUnreadMessagesByChatRoomIdAndUserId(
                     chatRoom.getChatRoomId(), userId, MessageStatus.UNREAD);
 
+            String messageContents = "채팅방에 메세지가 없습니다.";
+            if (latestMessage != null) {
+                if (latestMessage.getFileUrl() != null) {
+                    messageContents = "파일이 전송되었습니다.";
+                } else {
+                    messageContents = latestMessage.getMessageContents();
+                }
+            }
+
             ReadChatRoomResponse response = ReadChatRoomResponse.builder()
                     .workspaceId(workspaceId)
                     .chatroomId(chatRoom.getChatRoomId())
                     .chatRoomName(chatRoom.getChatRoomName())
-                    .messageContents(latestMessage != null ? latestMessage.getMessageContents() : "채팅방에 메세지가 없습니다.")
+                    .messageContents(messageContents)
                     .createdAt(latestMessage != null ? latestMessage.getCreatedAt() : chatRoom.getCreatedAt())
                     .UnreadMessages(unreadMessagesCount != null ? unreadMessagesCount.intValue() : 0)
                     .build();

--- a/backend/src/main/java/minionz/backend/chat/message/MessageController.java
+++ b/backend/src/main/java/minionz/backend/chat/message/MessageController.java
@@ -24,8 +24,8 @@ public class MessageController {
 
     // 메세지 전송
     @MessageMapping("/room/{chatRoomId}/send")
-    public void sendMessage(@Payload SendMessageRequest request, @AuthenticationPrincipal CustomSecurityUserDetails customUserDetails) {
-        Long senderId = customUserDetails.getUser().getUserId();
+    public void sendMessage(@Payload SendMessageRequest request) {
+        Long senderId = request.getUserId();
         messageService.sendMessage(request.getChatRoomId(), request, null, senderId);
     }
 

--- a/backend/src/main/java/minionz/backend/chat/message/model/request/SendMessageRequest.java
+++ b/backend/src/main/java/minionz/backend/chat/message/model/request/SendMessageRequest.java
@@ -14,4 +14,6 @@ public class SendMessageRequest {
     private String messageContents;
     private List<String> files;
     private Long chatRoomId;
+    private Long userId;
+    private String userName;
 }

--- a/backend/src/main/java/minionz/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/minionz/backend/config/SecurityConfig.java
@@ -17,15 +17,10 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.firewall.DefaultHttpFirewall;
 import org.springframework.security.web.firewall.HttpFirewall;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.util.Arrays;
 
 @Configuration
 @EnableWebSecurity
@@ -38,20 +33,6 @@ public class SecurityConfig {
     public WebSecurityCustomizer webSecurityCustomizer() {
         return web -> web.ignoring()
                 .requestMatchers(String.valueOf(PathRequest.toStaticResources().atCommonLocations()));
-    }
-
-    @Bean
-    public CorsConfigurationSource corsConfigurationSource() {
-        CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList("*")); // 모든 출처 허용
-        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS")); // OPTIONS 추가
-        configuration.setAllowedHeaders(Arrays.asList("X-Requested-With", "Content-Type", "Authorization", "X-XSRF-token"));
-        configuration.setAllowCredentials(false);
-        configuration.setMaxAge(3600L);
-
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration);
-        return source;
     }
 
     @Bean

--- a/backend/src/main/java/minionz/backend/config/web/WebConfig.java
+++ b/backend/src/main/java/minionz/backend/config/web/WebConfig.java
@@ -1,23 +1,23 @@
-//package minionz.backend.config.web;
-//
-//import org.springframework.beans.factory.annotation.Value;
-//import org.springframework.context.annotation.Configuration;
-//import org.springframework.web.servlet.config.annotation.CorsRegistry;
-//import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-//
-//@Configuration
-//public class WebConfig implements WebMvcConfigurer {
-//
-//    @Value("${address.domain}")
-//    private String[] domains; // 허용할 주소 나중에 설정하기 cors 에러
-//
-//    @Override
-//    public void addCorsMappings(CorsRegistry registry) {
-//        registry.addMapping("/**")
-//                .allowedOrigins(domains)
-//                .allowedMethods("GET", "POST", "PATCH", "DELETE")
-//                .allowedHeaders("Authorization", "Content-Type")
-//                .allowCredentials(true)
-//                .maxAge(3600);
-//    }
-//}
+package minionz.backend.config.web;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${address.domains}")
+    private String[] domains; // 허용할 주소 나중에 설정하기 cors 에러
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins(domains)
+                .allowedMethods("*")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(3600);
+    }
+}


### PR DESCRIPTION
## 연관된 이슈
#11 , #20 
<br>

## 작업 내용
- 채팅을 전송할 때 customUserDetails 로 userId를 받아오게 했었는데 현재 메세지 테스트를 해 보니 request 안에 id,name을 넣어주는 게 다른 변수가 일어나지 않아 좋다고 판단 되어 변경하게 되었습니다.
- cors 처리를 할 때 SecurityConfig와 WebConfig에서 겹치는 것을 발견하게 되었습니다.
  -  cors처리는 WebConfig에서만 하는 것이 적절하다고 생각 되어 SecurityConfig 내용을 없애고 합치게 되었습니다.
  - 이 과정에서 허용할 주소를 배열(domains)으로 받아 환경변수 처리를 해 뒀으며 yml 파일에 추가하면 허용할 주소가 유동적으로 변경되기에 이 방법이 더 적절하다고 판단 되어 변경 해 두었습니다.
<br> 

## 전달 사항
discord 안에 있는 pr 자료방에 domains에 넣어둘 값들을 추가 해 뒀습니다. yml 파일에 그대로 넣어주시면 됩니다.