### PR TITLE
[Feat] ETC_003 - KAFKA 그룹 아이디 및 설정 변경

### DIFF
--- a/backend/src/main/java/minionz/backend/chat/message/MessageService.java
+++ b/backend/src/main/java/minionz/backend/chat/message/MessageService.java
@@ -159,7 +159,7 @@ public class MessageService {
     }
 
 
-    @KafkaListener(topicPattern = "chat-room-.*", groupId = "${spring.kafka.consumer.group-id}")
+    @KafkaListener(topicPattern = "chat-room-.*")
     public void consumeMessage(ConsumerRecord<String, String> record) {
         try {
             SendMessageRequest request = objectMapper.readValue(record.value(), SendMessageRequest.class);

--- a/backend/src/main/java/minionz/backend/config/kafka/KafkaConstants.java
+++ b/backend/src/main/java/minionz/backend/config/kafka/KafkaConstants.java
@@ -1,0 +1,7 @@
+package minionz.backend.config.kafka;
+
+import java.util.UUID;
+
+public class KafkaConstants {
+    public static final String GROUP_ID = UUID.randomUUID().toString();
+}

--- a/backend/src/main/java/minionz/backend/config/kafka/KafkaConsumerConfig.java
+++ b/backend/src/main/java/minionz/backend/config/kafka/KafkaConsumerConfig.java
@@ -21,24 +21,25 @@ public class KafkaConsumerConfig {
     private String kafkaBroker;
 
     @Bean
-    public ConsumerFactory<String, String> stringConsumerFactory() {
-        return new DefaultKafkaConsumerFactory<>(stringConsumerConfig());
+    public ConsumerFactory<String, String> consumerFactory() {
+        return new DefaultKafkaConsumerFactory<>(consumerConfig());
     }
 
     @Bean
-    public Map<String, Object> stringConsumerConfig() {
+    public Map<String, Object> consumerConfig() {
         Map<String, Object> config = new HashMap<>();
         config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaBroker);
         config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+        config.put(ConsumerConfig.GROUP_ID_CONFIG, KafkaConstants.GROUP_ID);
         return config;
     }
 
     @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, String> stringKafkaListenerContainerFactory() {
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
         ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
-        factory.setConsumerFactory(stringConsumerFactory());
+        factory.setConsumerFactory(consumerFactory());
         return factory;
     }
 }

--- a/backend/src/main/java/minionz/backend/config/kafka/KafkaProducerConfig.java
+++ b/backend/src/main/java/minionz/backend/config/kafka/KafkaProducerConfig.java
@@ -5,6 +5,7 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
@@ -12,6 +13,7 @@ import org.springframework.kafka.core.ProducerFactory;
 import java.util.HashMap;
 import java.util.Map;
 
+@EnableKafka
 @Configuration
 public class KafkaProducerConfig {
 
@@ -19,12 +21,12 @@ public class KafkaProducerConfig {
     private String kafkaBroker;
 
     @Bean
-    public ProducerFactory<String, String> stringProducerFactory() {
-        return new DefaultKafkaProducerFactory<>(stringProducerConfig());
+    public ProducerFactory<String, String> producerFactory() {
+        return new DefaultKafkaProducerFactory<>(producerConfig());
     }
 
     @Bean
-    public Map<String, Object> stringProducerConfig() {
+    public Map<String, Object> producerConfig() {
         Map<String, Object> config = new HashMap<>();
         config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaBroker);
         config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
@@ -33,7 +35,7 @@ public class KafkaProducerConfig {
     }
 
     @Bean
-    public KafkaTemplate<String, String> stringKafkaTemplate() {
-        return new KafkaTemplate<>(stringProducerFactory());
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -86,7 +86,6 @@ spring:
       bootstrap-servers: ${KAFKA_SERVER}
     consumer:
       bootstrap-servers: ${KAFKA_SERVER}
-      group-id: ${KAFKA_CONSUMER_GROUP_ID}
 
 logging:
   level:
@@ -96,7 +95,6 @@ logging:
     org.apache.kafka: OFF
     kafka: OFF
     org.springframework.kafka: OFF
-
 
 cloud:
   aws:


### PR DESCRIPTION
## 연관된 이슈

<br>

## 작업 내용
- 원래 그룹 아이디를 지정 해 줘서 받아오고 있었는데, k8s에 배포를 하게 되면서 동시 배포에서 충돌을 방지하기 위해 uuid를 그룹 id로 받아오게 했습니다.
  - kafka consumer에서 메서드 이름을 맞춰줘야 제대로 동작하는 오류를 발견 했습니다.
  - 메서드 이름을 변경하고, uuid를 설정해 주는 클래스를 따로 파 받아오게 했습니다.
- application.yml 파일에서 그룹 아이디 관련 된 것을 삭제 해 줬습니다.

<br> 

## 전달 사항
없습니다....!
