### PR TITLE
[Feat] ISSUE_001,002,003 - 이슈 생성 수정 및 단일 조회, 리스트 조회 구현 [#144, #259, #260]

### DIFF
--- a/backend/src/main/java/minionz/backend/common/responses/BaseResponseStatus.java
+++ b/backend/src/main/java/minionz/backend/common/responses/BaseResponseStatus.java
@@ -64,6 +64,11 @@ public enum BaseResponseStatus {
     WORKSPACE_DASHBOARD_READ_SUCCESS(true, 4019, "워크스페이스 대시보드 조회에 성공했습니다. "),
     NOTE_REGISTER_SUCCESS(true,4020,"회의록 생성에 성공했습니다."),
     NOTE_SEARCH_SUCCESS(true,4021,"회의록 조회에 성공했습니다."),
+    ISSUE_RETRIEVAL_SUCCESS(true, 4022, "이슈 상세 조회에 성공했습니다."),
+    ISSUE_LIST_RETRIEVAL_SUCCESS(true, 4023, "이슈 리스트 조회에 성공했습니다."),
+    ISSUE_NOT_FOUND(false, 4024, "이슈가 존재하지 않습니다."),
+    ISSUE_WORKSPACE_MISMATCH(false, 4025, "이슈가 워스크페이스와 일치하지 않습니다."),
+    ISSUE_LIST_SUCCESS(true, 4026, "이슈 리스트 조회에 조회에 성공했습니다."),
 
     WORKSPACE_ACCESS_DENIED(false, 4101, "워크스페이스에 접근 권한이 없습니다."),
     WORKSPACE_NOT_EXISTS(false, 4102, "존재하지 않는 워크스페이스입니다."),

--- a/backend/src/main/java/minionz/backend/scrum/issue/IssueController.java
+++ b/backend/src/main/java/minionz/backend/scrum/issue/IssueController.java
@@ -5,7 +5,10 @@ import minionz.backend.common.exception.BaseException;
 import minionz.backend.common.responses.BaseResponse;
 import minionz.backend.common.responses.BaseResponseStatus;
 import minionz.backend.scrum.issue.model.request.CreateIssueRequest;
+import minionz.backend.scrum.issue.model.response.ReadIssueResponse;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/issue")
@@ -25,4 +28,25 @@ public class IssueController {
         return new BaseResponse<>(BaseResponseStatus.ISSUE_CREATE_SUCCESS);
     }
 
+    // 이슈 상세 조회
+    @GetMapping("/{workspaceId}/detail/{issueId}")
+    public BaseResponse<ReadIssueResponse> detailIssue(@PathVariable Long workspaceId, @PathVariable Long issueId) {
+        try {
+            ReadIssueResponse response = issueService.detailIssue(workspaceId, issueId);
+            return new BaseResponse<>(BaseResponseStatus.ISSUE_RETRIEVAL_SUCCESS, response);
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
+    // 이슈 리스트 조회
+    @GetMapping("/{workspaceId}/list")
+    public BaseResponse<List<ReadIssueResponse>> listIssues(@PathVariable Long workspaceId) {
+        try {
+            List<ReadIssueResponse> response = issueService.listIssues(workspaceId);
+            return new BaseResponse<>(BaseResponseStatus.ISSUE_LIST_SUCCESS, response);
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
 }

--- a/backend/src/main/java/minionz/backend/scrum/issue/IssueRepository.java
+++ b/backend/src/main/java/minionz/backend/scrum/issue/IssueRepository.java
@@ -24,4 +24,6 @@ public interface IssueRepository extends JpaRepository<Issue, Long> {
             "WHERE w.workspaceId = :workspaceId " +
             "AND i.status = true ")
     int findWorkspaceIssuesCount(Long workspaceId);
+
+    List<Issue> findByWorkspace_WorkspaceId(Long workspaceId);
 }

--- a/backend/src/main/java/minionz/backend/scrum/issue/IssueService.java
+++ b/backend/src/main/java/minionz/backend/scrum/issue/IssueService.java
@@ -1,11 +1,17 @@
 package minionz.backend.scrum.issue;
 
 import lombok.RequiredArgsConstructor;
+import minionz.backend.common.exception.BaseException;
+import minionz.backend.common.responses.BaseResponseStatus;
 import minionz.backend.scrum.issue.model.Issue;
 import minionz.backend.scrum.issue.model.request.CreateIssueRequest;
+import minionz.backend.scrum.issue.model.response.ReadIssueResponse;
 import minionz.backend.scrum.workspace.model.Workspace;
 import minionz.backend.user.model.User;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -14,14 +20,56 @@ public class IssueService {
 
     public void createIssue(Long workspaceId, CreateIssueRequest request) {
         issueRepository.save(
-                Issue
-                        .builder()
+                Issue.builder()
                         .issueTitle(request.getTitle())
                         .issueContents(request.getContents())
                         .status(true)
+                        .startDate(request.getStartDate())
+                        .endDate(request.getEndDate())
+                        .assignees(request.getAssignees())
+                        .reviewers(request.getReviewers())
                         .workspace(Workspace.builder().workspaceId(workspaceId).build())
                         .user(User.builder().userId(request.getManagerId()).build())
                         .build()
         );
     }
+
+    // 개별 이슈 조회
+    public ReadIssueResponse detailIssue(Long workspaceId, Long issueId) throws BaseException{
+        // 이슈 존재 확인
+        Issue issue = issueRepository.findById(issueId)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.ISSUE_NOT_FOUND));
+
+        // 이슈와 워크스페이스 일치
+        if (!issue.getWorkspace().getWorkspaceId().equals(workspaceId)) {
+            throw new BaseException(BaseResponseStatus.ISSUE_WORKSPACE_MISMATCH);
+        }
+
+        return ReadIssueResponse.builder()
+                .title(issue.getIssueTitle())
+                .contents(issue.getIssueContents())
+                .assignees(issue.getAssignees())
+                .reviewers(issue.getReviewers())
+                .startDate(issue.getStartDate())
+                .endDate(issue.getEndDate())
+                .status(issue.isStatus())
+                .build();
+    }
+
+    // 리스트 조회
+    public List<ReadIssueResponse> listIssues(Long workspaceId) {
+        List<Issue> issues = issueRepository.findByWorkspace_WorkspaceId(workspaceId);
+
+        return issues.stream().map(issue -> ReadIssueResponse.builder()
+                        .title(issue.getIssueTitle())
+                        .contents(issue.getIssueContents())
+                        .reviewers(issue.getReviewers())
+                        .assignees(issue.getAssignees())
+                        .startDate(issue.getStartDate())
+                        .endDate(issue.getEndDate())
+                        .status(issue.isStatus())
+                        .build())
+                .collect(Collectors.toList());
+    }
 }
+

--- a/backend/src/main/java/minionz/backend/scrum/issue/model/Issue.java
+++ b/backend/src/main/java/minionz/backend/scrum/issue/model/Issue.java
@@ -6,6 +6,9 @@ import minionz.backend.common.BaseEntity;
 import minionz.backend.scrum.workspace.model.Workspace;
 import minionz.backend.user.model.User;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Getter
 @Setter
 @NoArgsConstructor
@@ -19,7 +22,15 @@ public class Issue extends BaseEntity {
 
     private String issueTitle;
     private String issueContents;
-    private Boolean status;
+
+    private boolean status;
+
+    // 시작일과 종료일 추가
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+
+    private String assignees;
+    private String reviewers;
 
     // Issue : Workspace = N : 1
     @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/minionz/backend/scrum/issue/model/request/CreateIssueRequest.java
+++ b/backend/src/main/java/minionz/backend/scrum/issue/model/request/CreateIssueRequest.java
@@ -3,10 +3,20 @@ package minionz.backend.scrum.issue.model.request;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Getter
 @Builder
 public class CreateIssueRequest {
     private String title;
     private String contents;
-    private Long managerId;
+
+    private Long managerId; // 담당자
+    private String assignees; // 할당자
+    private String reviewers; // 리뷰어
+
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+
 }

--- a/backend/src/main/java/minionz/backend/scrum/issue/model/response/ReadIssueResponse.java
+++ b/backend/src/main/java/minionz/backend/scrum/issue/model/response/ReadIssueResponse.java
@@ -1,0 +1,22 @@
+package minionz.backend.scrum.issue.model.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ReadIssueResponse {
+    private String title;
+    private String contents;
+
+    private String reviewers;
+    private String assignees;
+
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+
+    private boolean status;
+    // 1이 InProgress, 0이 Done
+}


### PR DESCRIPTION
## 연관된 이슈
#144 #259 #260 
<br>

## 작업 내용
- 프론트와 상의하여 이슈 생성할 때 받는 값을 수정 했습니다.
- 단일 조회 및 리스트 조회 부분을 구현 했습니다.
  - 이슈는 워크스페이스 내에 생성 되며, workspaceId를 받아 그 워크스페이스내에 있는 이슈 리스트를 조회하거나, 단일 조회를 할 수 있도록 구성했고, api 명세서를 추가 해놨습니다.
<br> 

## 전달 사항
리뷰어와, 할당자의 역할이 List로 구현 되어야 하는데 생성할 때 Entity안에 List를 넣을 수 없음을 인지 하고 일단은 단일만 넣게 해뒀습니다. 이 문제는 리뷰어와 할당자의 Entity를 만들지 팀원과 상의 후 변경 하겠습니다.

잠깐 테스트 할 때는 권한 설정을 꺼두고 했습니다. 되는 것을 확인 후 올립니다.

close #260 
close #259 