### PR TITLE
[Fix] 캘린더 위클리 조회 오류 수정

### DIFF
--- a/frontend/src/view/schedule/monthly/component/MonthlyComponent.vue
+++ b/frontend/src/view/schedule/monthly/component/MonthlyComponent.vue
@@ -1,21 +1,10 @@
 <script setup>
-import { ref, onMounted, defineEmits, defineProps } from 'vue';
+import { ref, onMounted, defineEmits } from 'vue';
 import { useRoute } from 'vue-router';
 import PerfectScrollbar from 'perfect-scrollbar';
 import ScheduleModal from '@/view/schedule/component/ScheduleModal.vue';
 import { useCalendar } from '@/utils/calendarUtils';
 import { formatUtil } from '@/utils/dateUtils';
-
-const props = defineProps({
-  startDate: {
-    type: String,
-    default: ''
-  },
-  endDate: {
-    type: String,
-    default: ''
-  }
-});
 
 const emit = defineEmits(['prevMonth', 'nextMonth']);
 
@@ -64,7 +53,7 @@ const events = ref([]);
 
 const eventsForDay = (day) => {
   return events.value.filter(
-      (event) => formatUtil(event.date, 'd') === String(day)
+    (event) => formatUtil(event.date, 'd') === String(day)
   );
 };
 
@@ -90,22 +79,22 @@ const handleNextMonth = () => {
       </div>
       <div class="calendar-tab">
         <router-link
-            v-if="workspaceId"
-            :to="`/workspace/${workspaceId}/schedule/monthly`"
-            class="on"
-        >Month
+          v-if="workspaceId"
+          :to="`/workspace/${workspaceId}/schedule/monthly`"
+          class="on"
+          >Month
         </router-link>
         <router-link
-            v-if="workspaceId"
-            :to="`/workspace/${workspaceId}/schedule/weekly`"
-            class="off"
-        >Week
+          v-if="workspaceId"
+          :to="`/workspace/${workspaceId}/schedule/weekly`"
+          class="off"
+          >Week
         </router-link>
         <router-link v-if="!workspaceId" :to="`/my/schedule/monthly`" class="on"
-        >My Month
+          >My Month
         </router-link>
         <router-link v-if="!workspaceId" :to="`/my/schedule/weekly`" class="off"
-        >My Week
+          >My Week
         </router-link>
       </div>
     </div>
@@ -122,10 +111,10 @@ const handleNextMonth = () => {
         <div class="day-number">{{ day }}</div>
         <div class="events">
           <button
-              v-for="event in eventsForDay(day)"
-              :key="event.id"
-              class="event"
-              @click="show($event, event)"
+            v-for="event in eventsForDay(day)"
+            :key="event.id"
+            class="event"
+            @click="show($event, event)"
           >
             {{ event.title }}
           </button>
@@ -133,13 +122,13 @@ const handleNextMonth = () => {
       </div>
     </div>
     <ScheduleModal
-        v-if="isVisible"
-        :title="eventData.title"
-        :contents="eventData.contents"
-        :start-date="eventData.startDate"
-        :end-date="eventData.endDate"
-        :participants="eventData.participants"
-        @close="isVisible = false"
+      v-if="isVisible"
+      :title="eventData.title"
+      :contents="eventData.contents"
+      :start-date="eventData.startDate"
+      :end-date="eventData.endDate"
+      :participants="eventData.participants"
+      @close="isVisible = false"
     />
   </div>
 </template>

--- a/frontend/src/view/schedule/weekly/MyWeeklyPage.vue
+++ b/frontend/src/view/schedule/weekly/MyWeeklyPage.vue
@@ -1,10 +1,10 @@
 <script setup>
-import { inject, ref } from "vue";
-import { useMyDashboardStore } from "@/stores/myspace/useMyDashboardStore";
-import WeeklyComponent from "@/view/schedule/weekly/component/WeeklyComponent.vue";
-import WeeklyIssues from "@/view/schedule/weekly/component/WeeklyIssues.vue";
-import WeeklyTasks from "@/view/schedule/weekly/component/WeeklyTasks.vue";
-import MiniCalendar from "@/view/schedule/weekly/component/MiniCalendar.vue";
+import { inject, ref } from 'vue';
+import { useMyDashboardStore } from '@/stores/myspace/useMyDashboardStore';
+import WeeklyComponent from '@/view/schedule/weekly/component/WeeklyComponent.vue';
+import WeeklyIssues from '@/view/schedule/weekly/component/WeeklyIssues.vue';
+import WeeklyTasks from '@/view/schedule/weekly/component/WeeklyTasks.vue';
+import MiniCalendar from '@/view/schedule/weekly/component/MiniCalendar.vue';
 
 const contentsTitle = inject('contentsTitle');
 const contentsDescription = inject('contentsDescription');
@@ -16,7 +16,7 @@ const myWeek = ref({
   sprints: [],
   meetings: [],
   tasks: [],
-  issues: []
+  issues: [],
 });
 
 const mypageStore = useMyDashboardStore();
@@ -29,13 +29,24 @@ const updateSelectedWeek = (week) => {
 
 <template>
   <div class="weekly">
-    <WeeklyComponent :selected-week="selectedWeek" @update:selected-week="updateSelectedWeek"
-                     :sprints="myWeek.sprints" :meetings="myWeek.meetings"/>
+    <WeeklyComponent
+      :selected-week="selectedWeek"
+      @update:selected-week="updateSelectedWeek"
+      :sprints="myWeek.sprints"
+      :meetings="myWeek.meetings"
+    />
     <div class="week-data">
-      <MiniCalendar @update:selected-week="updateSelectedWeek"/>
+      <MiniCalendar @update:selected-week="updateSelectedWeek" />
       <div class="mini-lists">
-        <WeeklyIssues :selected-week="selectedWeek" :meetings="myWeeklyMeeting" :issues="myWeek.issues"/>
-        <WeeklyTasks :selected-week="selectedWeek" :tasks="myWeek.tasks"/>
+        <WeeklyIssues
+          :selected-week="selectedWeek"
+          :meetings="myWeeklyMeeting"
+          :issues="mypageStore.mySprintData.issues"
+        />
+        <WeeklyTasks
+          :selected-week="selectedWeek"
+          :tasks="mypageStore.mySprintData.tasks"
+        />
       </div>
     </div>
   </div>

--- a/frontend/src/view/schedule/weekly/WorkSpaceWeeklyPage.vue
+++ b/frontend/src/view/schedule/weekly/WorkSpaceWeeklyPage.vue
@@ -1,11 +1,11 @@
 <script setup>
-import {inject, ref} from "vue";
-import {useRoute} from "vue-router";
-import { useWorkspaceDashboardStore } from "@/stores/workspace/useWorkspaceDashboardStore"
-import WeeklyComponent from "@/view/schedule/weekly/component/WeeklyComponent.vue";
-import WeeklyScheduleComponent from "@/view/schedule/weekly/component/WeeklyIssues.vue";
-import WeeklyTask from "@/view/schedule/weekly/component/WeeklyTasks.vue";
-import MiniCalendar from "@/view/schedule/weekly/component/MiniCalendar.vue";
+import { inject, ref } from 'vue';
+import { useRoute } from 'vue-router';
+import { useWorkspaceDashboardStore } from '@/stores/workspace/useWorkspaceDashboardStore';
+import WeeklyComponent from '@/view/schedule/weekly/component/WeeklyComponent.vue';
+import WeeklyScheduleComponent from '@/view/schedule/weekly/component/WeeklyIssues.vue';
+import WeeklyTask from '@/view/schedule/weekly/component/WeeklyTasks.vue';
+import MiniCalendar from '@/view/schedule/weekly/component/MiniCalendar.vue';
 
 const route = useRoute();
 const workspaceId = route.params.workspaceId;
@@ -25,19 +25,28 @@ const updateSelectedWeek = (week) => {
 
 <template>
   <div class="weekly">
-    <WeeklyComponent :selected-week="selectedWeek" @update:selected-week="updateSelectedWeek" />
+    <WeeklyComponent
+      :selected-week="selectedWeek"
+      @update:selected-week="updateSelectedWeek"
+    />
     <div class="week-data">
-      <MiniCalendar @update:selectedWeek="updateSelectedWeek"/>
+      <MiniCalendar @update:selectedWeek="updateSelectedWeek" />
       <div class="mini-lists">
-        <WeeklyScheduleComponent :selected-week="selectedWeek" />
-        <WeeklyTask :selected-week="selectedWeek"/>
+        <WeeklyScheduleComponent
+          :selected-week="selectedWeek"
+          :issues="dashboardStore.workspaceWeeklyData.issues"
+        />
+        <WeeklyTask
+          :selected-week="selectedWeek"
+          :tasks="dashboardStore.workspaceWeeklyData.tasks"
+        />
       </div>
     </div>
   </div>
 </template>
 
 <style scoped>
-.weekly{
+.weekly {
   padding: 30px;
   height: 85vh;
   display: flex;
@@ -47,14 +56,14 @@ const updateSelectedWeek = (week) => {
   box-sizing: border-box;
 }
 
-.week-data{
+.week-data {
   display: flex;
   justify-content: space-between;
   gap: 20px;
   align-items: flex-end;
 }
 
-.mini-lists{
+.mini-lists {
   width: calc(100% - 350px);
   display: flex;
   height: 235px;

--- a/frontend/src/view/schedule/weekly/component/WeeklyIssues.vue
+++ b/frontend/src/view/schedule/weekly/component/WeeklyIssues.vue
@@ -3,11 +3,18 @@ import { ref, defineProps } from 'vue';
 import issue from '@/assets/icon/schedule/meeting.svg';
 
 const props = defineProps({ issues: { type: Array, default: () => [] } });
-const scheduleItems = ref(Array.isArray(props.issues) ? props.issues.map(issue => ({
-  title: issue.title,
-  time: new Date(issue.startDate).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
-  icon: issue
-})) : []);
+const scheduleItems = ref(
+  Array.isArray(props.issues)
+    ? props.issues.map((issue) => ({
+        title: issue.title,
+        time: new Date(issue.startDate).toLocaleTimeString([], {
+          hour: '2-digit',
+          minute: '2-digit',
+        }),
+        icon: issue,
+      }))
+    : []
+);
 </script>
 
 <template>
@@ -17,7 +24,7 @@ const scheduleItems = ref(Array.isArray(props.issues) ? props.issues.map(issue =
       issue가 없습니다
     </div>
     <div v-else>
-      <div v-for="(item, index) in scheduleItems" :key="index" class="schedule-item">
+      <div v-for="(item, index) in issues" :key="index" class="schedule-item">
         <img :src="issue" alt="icon" class="schedule-icon" />
         <div class="schedule-info">
           <div class="schedule-title">{{ item.title }}</div>

--- a/frontend/src/view/schedule/weekly/component/WeeklyTasks.vue
+++ b/frontend/src/view/schedule/weekly/component/WeeklyTasks.vue
@@ -1,27 +1,20 @@
 <script setup>
-import { ref, defineProps } from 'vue';
+import { defineProps } from 'vue';
 import taskImg from '@/assets/icon/schedule/task.svg';
 
 const props = defineProps({ tasks: { type: Array, default: () => [] } });
-const taskWeek = ref(
-  (props.tasks || []).map((task) => ({
-    title: task.title,
-    details: task.label,
-    icon: task,
-  }))
-);
 </script>
 
 <template>
   <div class="imminent-tasks">
     <p class="imminent-tasks-title">Imminent Tasks</p>
-    <div v-if="taskWeek.length === 0" class="no-tasks">task가 없습니다</div>
+    <div v-if="props.length === 0" class="no-tasks">task가 없습니다</div>
     <div v-else>
       <div v-for="(task, index) in tasks" :key="index" class="task-item">
         <img :src="taskImg" alt="icon" class="task-icon" />
         <div class="task-info">
           <div class="task-title">{{ task.title }}</div>
-          <div class="task-details">{{ task.details }}</div>
+          <div class="task-details">{{ task.label }}</div>
         </div>
       </div>
     </div>

--- a/frontend/src/view/schedule/weekly/component/WeeklyTasks.vue
+++ b/frontend/src/view/schedule/weekly/component/WeeklyTasks.vue
@@ -3,22 +3,21 @@ import { ref, defineProps } from 'vue';
 import taskImg from '@/assets/icon/schedule/task.svg';
 
 const props = defineProps({ tasks: { type: Array, default: () => [] } });
-const taskWeek = ref((props.tasks || []).map(task => ({
-  title: task.title,
-  details: task.label,
-  icon: task
-})));
+const taskWeek = ref(
+  (props.tasks || []).map((task) => ({
+    title: task.title,
+    details: task.label,
+    icon: task,
+  }))
+);
 </script>
 
 <template>
   <div class="imminent-tasks">
     <p class="imminent-tasks-title">Imminent Tasks</p>
-    <div v-if="taskWeek.length === 0" class="no-tasks">
-      task가 없습니다
-    </div>
+    <div v-if="taskWeek.length === 0" class="no-tasks">task가 없습니다</div>
     <div v-else>
-      <p class="imminent-tasks-title">Imminent tasks</p>
-      <div v-for="(task, index) in taskWeek" :key="index" class="task-item">
+      <div v-for="(task, index) in tasks" :key="index" class="task-item">
         <img :src="taskImg" alt="icon" class="task-icon" />
         <div class="task-info">
           <div class="task-title">{{ task.title }}</div>


### PR DESCRIPTION
## 연관된 이슈
<!-- 관련된 이슈 번호를 적어주세요 -->
<br>

## 작업 내용
<!-- 작업에 대한 설명을 적어주세요 -->
- 사용하지 않는 변수를 제거했습니다.
- 중복되는 p 태그를 삭제했습니다.
-  워크스페이스 및 마이스페이스에서 위클리 캘린더 조회 시, 프롭스를 전달하지 않아서 데이터를 받지 못하는 문제를 해결했습니다. 
-  바인딩되는 변수를 수정하여 비동기 처리가 안정적이도록 수정했습니다. 
<br> 

## 전달 사항
<!-- 참고할 사항이 있다면 알려주세요 -->
