### PR TITLE
[Feat] CHAT_007 - 채팅방 별 파일 내역 조회 기능 구현 [#25]

### DIFF
--- a/backend/api-server/src/main/java/minionz/apiserver/chat/chat_room/model/response/FileInfoResponse.java
+++ b/backend/api-server/src/main/java/minionz/apiserver/chat/chat_room/model/response/FileInfoResponse.java
@@ -1,0 +1,14 @@
+package minionz.apiserver.chat.chat_room.model.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class FileInfoResponse {
+    private String fileName;
+    private String fileUrl;
+    private String  fileSize;
+    private String fileType;
+}
+

--- a/backend/api-server/src/main/java/minionz/apiserver/chat/message/MessageController.java
+++ b/backend/api-server/src/main/java/minionz/apiserver/chat/message/MessageController.java
@@ -1,6 +1,7 @@
 package minionz.apiserver.chat.message;
 
 import lombok.RequiredArgsConstructor;
+import minionz.apiserver.chat.chat_room.model.response.FileInfoResponse;
 import minionz.apiserver.chat.chat_room.model.response.ReadMessageResponse;
 import minionz.apiserver.chat.message.model.request.SendMessageRequest;
 import minionz.apiserver.chat.message.model.request.UpdateMessageRequest;
@@ -58,7 +59,18 @@ public class MessageController {
     } catch (BaseException e) {
       return new BaseResponse<>(e.getStatus());
     }
+  }
 
+  // 파일 내역 조회
+  @GetMapping(value = "/message/{chatRoomId}/files")
+  public BaseResponse<List<FileInfoResponse>> getFileMessages(
+          @PathVariable Long chatRoomId) {
+    try {
+      List<FileInfoResponse> response = messageService.getFileList(chatRoomId);
+      return new BaseResponse<>(BaseResponseStatus.FILE_RETRIEVAL_SUCCESS, response);
+    } catch (BaseException e) {
+      return new BaseResponse<>(e.getStatus());
+    }
   }
 
   // 메세지 수정

--- a/backend/api-server/src/main/java/minionz/apiserver/chat/message/MessageRepository.java
+++ b/backend/api-server/src/main/java/minionz/apiserver/chat/message/MessageRepository.java
@@ -29,11 +29,14 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
             "ORDER BY m.createdAt DESC")
     List<Message> findLatestMessagesByChatRoomId(Long chatRoomId);
 
-    @Query("SELECT m FROM Message m WHERE m.chatParticipation.chatRoom.chatRoomId = :chatRoomId AND m.deletedAt IS NULL ORDER BY m.createdAt ASC")
-    Page<Message> findByChatRoomIdAndDeletedAtIsNullOrderByCreatedAtAsc(Long chatRoomId, Pageable pageable);
+    @Query("SELECT m FROM Message m WHERE m.chatParticipation.chatRoom.chatRoomId = :chatRoomId AND m.deletedAt IS NULL ORDER BY m.createdAt DESC")
+    Page<Message> findByChatRoomIdAndDeletedAtIsNull(Long chatRoomId, Pageable pageable);
 
     @Query("SELECT m FROM Message m WHERE m.messageId = :messageId")
     Message findMessageById(Long messageId);
+
+    @Query("SELECT m FROM Message m WHERE m.chatParticipation.chatRoom.chatRoomId = :chatRoomId AND m.messageType = 'FILE' AND m.deletedAt IS NULL")
+    List<Message> findFilesByChatRoomId(Long chatRoomId);
 
     @Query("SELECT m FROM Message m " +
             "WHERE m.chatRoomId = :chatRoomId " +

--- a/backend/api-server/src/main/java/minionz/apiserver/common/responses/BaseResponseStatus.java
+++ b/backend/api-server/src/main/java/minionz/apiserver/common/responses/BaseResponseStatus.java
@@ -155,6 +155,8 @@ public enum BaseResponseStatus {
 
     CHATROOM_SEARCH_SUCCESS(true, 6801, "채팅방 검색에 성공했습니다."),
     MESSAGE_UPDATE_FAILED(false, 6902, "메시지 업데이트에 실패했습니다."),
+    FILE_RETRIEVAL_SUCCESS(true, 6903, "파일 내역 조회에 성공했습니다."),
+    FILE_NOT_FOUND(false, 6904, "파일 내역 조회에 실패했습니다."),
 
 
     /**


### PR DESCRIPTION
## 연관된 이슈
#25 
<br>

## 작업 내용
- 채팅방 내용 조회에서 메세지 타입을 file로 해서 파일과 메세지를 구분 했는데, 무한 스크롤 처리를 하면서 메세지를 올려야 파일 목록 또한 받아오는 것을 발견했습니다.
  - 이를 개선하기 위해, 파일 내역 조회 기능을 아예 구현하여 별도로 처리되게 설정 했습니다.
<br> 

## 전달 사항
<!-- 참고할 사항이 있다면 알려주세요 -->
