### PR TITLE
[Feat] CHATBOT_001 - 챗봇 Ai 연결 기능 구현 [#371]

### DIFF
--- a/backend/api-server/src/main/java/minionz/apiserver/chat/chat_bot/ChatBotController.java
+++ b/backend/api-server/src/main/java/minionz/apiserver/chat/chat_bot/ChatBotController.java
@@ -2,20 +2,51 @@ package minionz.apiserver.chat.chat_bot;
 
 import lombok.RequiredArgsConstructor;
 import minionz.apiserver.chat.chat_bot.model.request.ChatBotRequest;
+import minionz.apiserver.common.exception.BaseException;
+import minionz.apiserver.common.responses.BaseResponse;
+import minionz.apiserver.common.responses.BaseResponseStatus;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-import reactor.core.publisher.Mono;
+
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
 public class ChatBotController {
 
-    private final ChatBotService chatbotService;
+    private final ChatBotService chatBotService;
+    private final SimpMessagingTemplate messagingTemplate;
 
-    // GPT 로 질문을 보내고 응답을 받는 경로
-    @PostMapping("/chatbot/ask-ai")
-    public Mono<String> askAi(@RequestBody ChatBotRequest request) {
-        return chatbotService.askAi(request.getQuestion(), request.getUserId());
+    @MessageMapping("/bot/message")
+    public BaseResponse<String> chatBotMessage(@Payload ChatBotRequest request) {
+        try {
+            if (!request.isFromChatBot()) {
+                Long botQuestionId = chatBotService.saveUserMessage(request);
+                chatBotService.sendMessageToN8n(botQuestionId, request.getMessageContents(), request.getUserId());
+                return new BaseResponse<>(BaseResponseStatus.CHATBOT_MESSAGE_RECEIVED);
+            }
+            return new BaseResponse<>(BaseResponseStatus.CHATBOT_RESPONSE_SAVED);
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
+    // n8n에서 받은 응답
+    @PostMapping("/receiveFromN8n")
+    public BaseResponse<String> receiveFromN8n(@RequestBody Map<String, String> requestData) {
+        try {
+            String message = requestData.get("message");
+//            Long userId = Long.parseLong(requestData.get("userId"));
+            Long botQuestionId = Long.parseLong(requestData.get("botQuestionId"));
+            Long userId = chatBotService.saveChatBotResponse(message, botQuestionId);
+            messagingTemplate.convertAndSend("/subUser/" + userId, message);
+            return new BaseResponse<>(BaseResponseStatus.CHATBOT_RESPONSE_SAVED);
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
     }
 }

--- a/backend/api-server/src/main/java/minionz/apiserver/chat/chat_bot/ChatBotService.java
+++ b/backend/api-server/src/main/java/minionz/apiserver/chat/chat_bot/ChatBotService.java
@@ -1,95 +1,78 @@
 package minionz.apiserver.chat.chat_bot;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import minionz.apiserver.chat.chat_bot.model.request.ChatBotRequest;
 import minionz.apiserver.common.exception.BaseException;
 import minionz.apiserver.common.responses.BaseResponseStatus;
 import minionz.common.chat.chat_bot.ChatBotRepository;
 import minionz.common.chat.chat_bot.model.ChatBot;
 import minionz.common.user.UserRepository;
 import minionz.common.user.model.User;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
+import org.springframework.web.client.RestTemplate;
 
-import java.io.IOException;
-import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
 
 @Service
 @RequiredArgsConstructor
 public class ChatBotService {
 
-    private final WebClient.Builder webClientBuilder;
-    private final UserRepository userRepository;
     private final ChatBotRepository chatBotRepository;
-    private final ObjectMapper objectMapper;
+    private final UserRepository userRepository;
+    private final RestTemplate restTemplate = new RestTemplate();
 
-    @Value("${gemini.api-key}")
-    private String apiKey;
-
-    private static final String GEMINI_API_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent";
-
-    // GPT에 질문을 보내고, 응답을 저장하는 메서드
-    public Mono<String> askAi(String question, Long userId) {
-        // User 조회
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.USER_NOT_FOUND));
-
-        // 원래 DB에서 뭘 읽어와서 하려고 했는데 DB에서 읽어온 데이터를 형식으로 넣어주기?
-
-        String requestBody = """
-                {
-                  "contents": [
-                    {
-                      "parts": [
-                        {
-                          "text": "%s"
-                        }
-                      ]
-                    }
-                  ]
-                }
-                """.formatted(question);
-
-        return webClientBuilder.build()
-                .post()
-                .uri(GEMINI_API_URL + "?key=" + apiKey)  // Append API key to the URL
-                .header("Content-Type", "application/json")
-                .bodyValue(requestBody)
-                .retrieve()
-                .bodyToMono(String.class)
-                .map(response -> {
-                    // JSON에서 "text" 값 추출
-                    String responseText = extractTextFromResponse(response);
-                    // ChatBot 대화 저장
-                    saveChatBotConversation(question, responseText, user);
-                    return responseText;
-                });
-    }
-
-    // JSON 응답에서 "text" 값만 추출하는 메서드
-    private String extractTextFromResponse(String response) {
+    // 사용자 메시지를 DB에 저장
+    public Long saveUserMessage(ChatBotRequest request) {
         try {
-            JsonNode root = objectMapper.readTree(response);
-            return root.path("candidates").get(0)
-                    .path("content").path("parts").get(0)
-                    .path("text").asText();
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to parse response", e);
+            User user = userRepository.findById(request.getUserId())
+                    .orElseThrow(() -> new BaseException(BaseResponseStatus.CHATBOT_USER_NOT_FOUND));
+
+            ChatBot chatBotMessage = ChatBot.builder()
+                    .question(request.getMessageContents())  // 사용자 메시지 저장
+                    .user(user)
+                    .build();
+
+            chatBotMessage = chatBotRepository.save(chatBotMessage);
+            return chatBotMessage.getBotQuestionId();
+        } catch (Exception e) {
+            throw new BaseException(BaseResponseStatus.CHATBOT_DATABASE_ERROR);
         }
     }
 
-    // ChatBot 대화를 저장
-    private void saveChatBotConversation(String question, String response, User user) {
-        ChatBot chatBot = ChatBot.builder()
-                .user(user)
-                .question(question)
-                .response(response)
-                .timestamp(LocalDateTime.now())
-                .build();
-        chatBotRepository.save(chatBot);
+    // n8n으로 메시지를 전송하고 응답 받기
+    public String sendMessageToN8n(Long botQuestionId, String message, Long userId) {
+        String webhookUrl;
+        if (message.contains("회의록")) {
+            // 회의록 요약에 대한 요청
+            webhookUrl = "http://localhost:5678/webhook-test/calit-test2";
+        } else {
+            // 일반 회의에 대한 요청
+            webhookUrl = "http://localhost:5678/webhook-test/calit-test";
+        }
+
+        try {
+            Map<String, String> jsonMap = new HashMap<>();
+            jsonMap.put("message", message);
+            jsonMap.put("userId", String.valueOf(userId));
+            jsonMap.put("botQuestionId", String.valueOf(botQuestionId));
+            // n8n로 post -> webhook 동작
+            return restTemplate.postForObject(webhookUrl, jsonMap, String.class);
+        } catch (Exception e) {
+            throw new BaseException(BaseResponseStatus.CHATBOT_EXTERNAL_API_ERROR);
+        }
+    }
+
+    // 챗봇 응답을 DB에 저장
+    public Long saveChatBotResponse(String message, Long botQuestionId) {
+        try {
+            ChatBot chatBotResponse = chatBotRepository.findById(botQuestionId).orElseThrow();
+            chatBotResponse.setResponse(message);
+            chatBotRepository.save(chatBotResponse);
+            return chatBotResponse.getUser().getUserId();
+        } catch (Exception e) {
+            throw new BaseException(BaseResponseStatus.CHATBOT_DATABASE_ERROR);
+        }
     }
 }
-

--- a/backend/api-server/src/main/java/minionz/apiserver/chat/chat_bot/model/request/ChatBotRequest.java
+++ b/backend/api-server/src/main/java/minionz/apiserver/chat/chat_bot/model/request/ChatBotRequest.java
@@ -8,6 +8,7 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ChatBotRequest {
-    private String question;
+    private String messageContents;
     private Long userId;
+    private boolean isFromChatBot = false;
 }

--- a/backend/api-server/src/main/java/minionz/apiserver/common/responses/BaseResponseStatus.java
+++ b/backend/api-server/src/main/java/minionz/apiserver/common/responses/BaseResponseStatus.java
@@ -158,6 +158,12 @@ public enum BaseResponseStatus {
     MESSAGE_UPDATE_FAILED(false, 6902, "메시지 업데이트에 실패했습니다."),
     FILE_RETRIEVAL_SUCCESS(true, 6903, "파일 내역 조회에 성공했습니다."),
     FILE_NOT_FOUND(false, 6904, "파일 내역 조회에 실패했습니다."),
+    CHATBOT_MESSAGE_RECEIVED(true, 6903, "챗봇에게 메세지가 성공적으로 수신되었습니다."),
+    CHATBOT_RESPONSE_SAVED(true, 6904, "챗봇 응답이 성공적으로 저장되었습니다."),
+    CHATBOT_ERROR(false, 6905, "챗봇 처리 중 오류가 발생했습니다."),
+    CHATBOT_USER_NOT_FOUND(false, 6906, "챗봇 메시지를 처리하는 동안 사용자를 찾을 수 없습니다."),
+    CHATBOT_DATABASE_ERROR(false, 6907, "챗봇 데이터베이스 처리 중 오류가 발생했습니다."),
+    CHATBOT_EXTERNAL_API_ERROR(false, 6908, "외부 API 호출 중 챗봇 오류가 발생했습니다."),
 
 
     /**

--- a/backend/api-server/src/main/java/minionz/apiserver/config/web/WebSocketConfig.java
+++ b/backend/api-server/src/main/java/minionz/apiserver/config/web/WebSocketConfig.java
@@ -15,18 +15,21 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/chat")
-                .setAllowedOriginPatterns("*") // 모든 도메인에서의 CORS 허용
+                .setAllowedOriginPatterns("*")
                 .withSockJS();
         registry.addEndpoint("/note")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+        registry.addEndpoint("/chatbot")
                 .setAllowedOriginPatterns("*")
                 .withSockJS();
     }
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        // SimpleBroker로 두 개의 경로를 한 번에 설정
-        registry.enableSimpleBroker("/sub", "/topic/note");
-        registry.setApplicationDestinationPrefixes("/pub", "/app/note");
+        registry.enableSimpleBroker("/sub", "/topic/note", "/subUser");
+        registry.setApplicationDestinationPrefixes("/pub", "/app/note", "/pubBot");
     }
+
 
 }

--- a/backend/common/src/main/java/minionz/common/chat/chat_bot/model/ChatBot.java
+++ b/backend/common/src/main/java/minionz/common/chat/chat_bot/model/ChatBot.java
@@ -2,6 +2,7 @@ package minionz.common.chat.chat_bot.model;
 
 import jakarta.persistence.*;
 import lombok.*;
+import minionz.common.common.BaseEntity;
 import minionz.common.user.model.User;
 
 import java.time.LocalDateTime;
@@ -12,10 +13,10 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 @Entity
-public class ChatBot {
+public class ChatBot extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long chatBotId;
+    private Long botQuestionId;
 
     @Lob
     @Column(columnDefinition = "LONGTEXT")
@@ -25,9 +26,7 @@ public class ChatBot {
     @Column(columnDefinition = "LONGTEXT")
     private String response;
 
-    private LocalDateTime timestamp;
-
-    @ManyToOne
+    @OneToOne
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 }

--- a/backend/common/src/main/java/minionz/common/user/model/User.java
+++ b/backend/common/src/main/java/minionz/common/user/model/User.java
@@ -45,8 +45,8 @@ public class User {
     private Integer persona;
 
     // ChatBot 1 : 1
-    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
-    private List<ChatBot> chatBots = new ArrayList<>();
+    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY)
+    private ChatBot chatBot;
 
     // ChatParticipation 1 : N
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)


### PR DESCRIPTION
## 연관된 이슈
#371 
<br>

## 작업 내용
- 사용자가 챗봇에게 메세지를 보내는 것은 WebSocket STOMP를 활용하였습니다.
  - 이 메세지를 POST 형태로 N8N에 보내주고, N8N에서 WebHook을 실행시켜 자동화 워크플로우를 실행 시킵니다.
  - 이 워크플로우 안에는 회의록 요약 및 회의 자료 추천 기능들이 있습니다. 이 기능을 마치고, POST 형태로 서버에 응답을 주면, 이 응답을 사용자에게 다시 WebSocket STOMP를 활용하여 구독 된 사용자에게 전송하도록 구현했습니다. 
- 챗봇과 사용자의 연관 관계를 1:1로 재수정 하였습니다. 
- 챗봇 상태 코드들을 추가 하였으며, WebSocketConfig에 CHATBOT 부분 또한 추가 해 두었습니다.
<br> 

## 전달 사항
close #371
