### PR TITLE
[Fix] 토큰의 role 생성 수정

### DIFF
--- a/backend/api-server/src/main/java/minionz/apiserver/config/SecurityConfig.java
+++ b/backend/api-server/src/main/java/minionz/apiserver/config/SecurityConfig.java
@@ -230,6 +230,6 @@ public class SecurityConfig {
         public static final String ROLE_WORKSPACE_MEMBER = "W_M";
         public static final String ROLE_SPRINT_ADMIN = "S_A";
         public static final String ROLE_SPRINT_MEMBER = "S_M";
-        public static final String ROLE_MEETING_MEMBER = "M_M";
+//        public static final String ROLE_MEETING_MEMBER = "M_M";
     }
 }

--- a/backend/api-server/src/main/java/minionz/apiserver/config/SecurityConfig.java
+++ b/backend/api-server/src/main/java/minionz/apiserver/config/SecurityConfig.java
@@ -226,10 +226,10 @@ public class SecurityConfig {
     }
 
     public static class RoleConstants {
-        public static final String ROLE_WORKSPACE_ADMIN = "ROLE_WORKSPACE_ADMIN";
-        public static final String ROLE_WORKSPACE_MEMBER = "ROLE_WORKSPACE_MEMBER";
-        public static final String ROLE_SPRINT_ADMIN = "ROLE_SPRINT_ADMIN";
-        public static final String ROLE_SPRINT_MEMBER = "ROLE_SPRINT_MEMBER";
-        public static final String ROLE_MEETING_MEMBER = "ROLE_MEETING_MEMBER";
+        public static final String ROLE_WORKSPACE_ADMIN = "W_A";
+        public static final String ROLE_WORKSPACE_MEMBER = "W_M";
+        public static final String ROLE_SPRINT_ADMIN = "S_A";
+        public static final String ROLE_SPRINT_MEMBER = "S_M";
+        public static final String ROLE_MEETING_MEMBER = "M_M";
     }
 }

--- a/backend/api-server/src/main/java/minionz/apiserver/user/model/CustomSecurityUserDetails.java
+++ b/backend/api-server/src/main/java/minionz/apiserver/user/model/CustomSecurityUserDetails.java
@@ -47,7 +47,7 @@ public class CustomSecurityUserDetails implements UserDetails, OAuth2User {
         authorities.addAll(workspaceParticipations.stream()
                 .filter(participate -> participate.getIsValid())
                 .map(participate -> {
-                    String rolePrefix = participate.getIsManager() ? "ROLE_WORKSPACE_ADMIN_" : "ROLE_WORKSPACE_MEMBER_";
+                    String rolePrefix = participate.getIsManager() ? "W_A_" : "W_M_";
                     String roleName = rolePrefix + participate.getWorkspace().getWorkspaceId();
                     return new SimpleGrantedAuthority(roleName);
                 })
@@ -55,7 +55,7 @@ public class CustomSecurityUserDetails implements UserDetails, OAuth2User {
 
         authorities.addAll(sprintParticipations.stream()
                 .map(participate -> {
-                    String rolePrefix = participate.getIsManager() ? "ROLE_SPRINT_ADMIN_" : "ROLE_SPRINT_MEMBER_";
+                    String rolePrefix = participate.getIsManager() ? "S_A_" : "S_M_";
                     String roleName = rolePrefix + participate.getSprint().getSprintId();
                     return new SimpleGrantedAuthority(roleName);
                 })
@@ -63,7 +63,7 @@ public class CustomSecurityUserDetails implements UserDetails, OAuth2User {
 
         authorities.addAll(meetingParticipations.stream()
                 .map(participate -> {
-                    String roleName = "ROLE_MEETING_MEMBER_" + participate.getMeeting().getMeetingId();
+                    String roleName = "M_" + participate.getMeeting().getMeetingId();
                     return new SimpleGrantedAuthority(roleName);
                 })
                 .collect(Collectors.toList()));

--- a/backend/api-server/src/main/java/minionz/apiserver/user/model/CustomSecurityUserDetails.java
+++ b/backend/api-server/src/main/java/minionz/apiserver/user/model/CustomSecurityUserDetails.java
@@ -40,7 +40,7 @@ public class CustomSecurityUserDetails implements UserDetails, OAuth2User {
     public Collection<? extends GrantedAuthority> getAuthorities() {
         List<WorkspaceParticipation> workspaceParticipations = user.getWorkspaceParticipations();
         List<SprintParticipation> sprintParticipations = user.getSprintParticipations();
-        List<MeetingParticipation> meetingParticipations = user.getMeetingParticipations();
+//        List<MeetingParticipation> meetingParticipations = user.getMeetingParticipations();
 
         List<GrantedAuthority> authorities = new ArrayList<>();
 
@@ -61,12 +61,12 @@ public class CustomSecurityUserDetails implements UserDetails, OAuth2User {
                 })
                 .collect(Collectors.toList()));
 
-        authorities.addAll(meetingParticipations.stream()
-                .map(participate -> {
-                    String roleName = "M_" + participate.getMeeting().getMeetingId();
-                    return new SimpleGrantedAuthority(roleName);
-                })
-                .collect(Collectors.toList()));
+//        authorities.addAll(meetingParticipations.stream()
+//                .map(participate -> {
+//                    String roleName = "M_" + participate.getMeeting().getMeetingId();
+//                    return new SimpleGrantedAuthority(roleName);
+//                })
+//                .collect(Collectors.toList()));
 
         // 사용자 역할 추가
         authorities.add(new SimpleGrantedAuthority(user.getRole()));


### PR DESCRIPTION
## 연관된 이슈
<!-- 관련된 이슈 번호를 적어주세요 -->
<br>

## 작업 내용
<!-- 작업에 대한 설명을 적어주세요 -->
- 사용자가 참여하고 있는 스크럼 내역이 많을 때, 토큰의 role의 길이가 너무 길어져 토큰의 헤더가 너무 커져서 502 에러가 발생합니다. 토큰의 변수명의 길이를 대폭 줄여 수정했습니다. 
- 현재 사용하지 않는 미팅 참여 권한은 토큰 생성 시 참여 테이블에 추가하지 않도록 수정했습니다.
<br> 

## 전달 사항
<!-- 참고할 사항이 있다면 알려주세요 -->
여전히 참여 내역이 많을 때는 문제가 발생할 수 있습니다.