### PR TITLE
[Feat] api 요청 예외처리 및 데이터 타입 수정

### DIFF
--- a/frontend/src/stores/myspace/useMyDashboardStore.js
+++ b/frontend/src/stores/myspace/useMyDashboardStore.js
@@ -1,37 +1,67 @@
 import { ref } from 'vue';
-import { axiosInstance } from "@/utils/axiosInstance";
+import { axiosInstance } from '@/utils/axiosInstance';
 import { defineStore } from 'pinia';
-import { weeklySettingUtils } from "@/utils/scheduleDateSettingUtils";
+import { weeklySettingUtils } from '@/utils/scheduleDateSettingUtils';
+import { Notyf } from 'notyf';
+import 'notyf/notyf.min.css';
+
+const notyf = new Notyf();
 
 export const useMyDashboardStore = defineStore('mypageStore', () => {
-    const mySprintData = ref([]);
-    const getMyKanban = async () => {
-        const response = await axiosInstance.get('/api/task/my/all');
-        mySprintData.value = response.data.result;
-    };
+  const mySprintData = ref([]);
+  const getMyKanban = async () => {
+    const response = await axiosInstance.get('/api/task/my/all');
 
-    const getMyMonthly = async ({ startDate, endDate }) => {
-        const response = await axiosInstance.get(`/api/schedule/my/monthly?startDate=${startDate}&endDate=${endDate}`);
-        mySprintData.value = response.data.result;
+    if (response.data.success) {
+      mySprintData.value = response.data.result;
+    } else {
+      notyf.error(response.data.message);
     }
+  };
 
-    const getMyWeekly = async () => {
-        const { startDate, endDate } = weeklySettingUtils();
-        const response = await axiosInstance.get(`/api/schedule/my/weekly?startDate=${startDate}&endDate=${endDate}`);
-        mySprintData.value = response.data.result;
+  const getMyMonthly = async ({ startDate, endDate }) => {
+    const response = await axiosInstance.get(
+      `/api/schedule/my/monthly?startDate=${startDate}&endDate=${endDate}`
+    );
+
+    if (response.data.success) {
+      mySprintData.value = response.data.result;
+    } else {
+      notyf.error(response.data.message);
     }
+  };
 
-    const getMyDashboard = async () => {
-        const { startDate, endDate } = weeklySettingUtils();
-        const response = await axiosInstance.get(`/api/dashboard/my?startDate=${startDate}&endDate=${endDate}`);
-        mySprintData.value = response.data.result;
+  const getMyWeekly = async () => {
+    const { startDate, endDate } = weeklySettingUtils();
+    const response = await axiosInstance.get(
+      `/api/schedule/my/weekly?startDate=${startDate}&endDate=${endDate}`
+    );
+
+    if (response.data.success) {
+      mySprintData.value = response.data.result;
+    } else {
+      notyf.error(response.data.message);
     }
+  };
 
-    return {
-        mySprintData,
-        getMyKanban,
-        getMyMonthly,
-        getMyWeekly,
-        getMyDashboard
-    };
-})
+  const getMyDashboard = async () => {
+    const { startDate, endDate } = weeklySettingUtils();
+    const response = await axiosInstance.get(
+      `/api/dashboard/my?startDate=${startDate}&endDate=${endDate}`
+    );
+
+    if (response.data.success) {
+      mySprintData.value = response.data.result;
+    } else {
+      notyf.error(response.data.message);
+    }
+  };
+
+  return {
+    mySprintData,
+    getMyKanban,
+    getMyMonthly,
+    getMyWeekly,
+    getMyDashboard,
+  };
+});

--- a/frontend/src/stores/scrum/useIssueStore.js
+++ b/frontend/src/stores/scrum/useIssueStore.js
@@ -1,6 +1,10 @@
 import { ref } from 'vue';
 import { axiosInstance } from '@/utils/axiosInstance';
 import { defineStore } from 'pinia';
+import { Notyf } from 'notyf';
+import 'notyf/notyf.min.css';
+
+const notyf = new Notyf();
 
 export const useIssueStore = defineStore('issueStore', () => {
   const issues = ref([]);
@@ -11,9 +15,19 @@ export const useIssueStore = defineStore('issueStore', () => {
         `/api/issue/${workspaceId}`,
         data
       );
-      issues.value.push(response.data.result);
+
+      if (response.data.success) {
+        issues.value.push(response.data.result);
+      } else {
+        notyf.error(response.data.message);
+      }
     } catch (error) {
-      console.error('Error adding issue:', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error('Error adding issue:', error);
+      }
     }
   };
 
@@ -22,9 +36,19 @@ export const useIssueStore = defineStore('issueStore', () => {
       const response = await axiosInstance.get(
         `/api/issue/${workspaceId}/list`
       );
-      issues.value = response.data.result;
+
+      if (response.data.success) {
+        issues.value = response.data.result;
+      } else {
+        notyf.error(response.data.message);
+      }
     } catch (error) {
-      console.error('Error fetching issues:', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error('Error fetching issues:', error);
+      }
     }
   };
 
@@ -33,9 +57,19 @@ export const useIssueStore = defineStore('issueStore', () => {
       const response = await axiosInstance.get(
         `/api/issue/${workspaceId}/detail/${issueId}`
       );
-      issues.value = response.data.result;
+
+      if (response.data.success) {
+        issues.value = response.data.result;
+      } else {
+        notyf.error(response.data.message);
+      }
     } catch (error) {
-      console.error('Error fetching issues:', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error('Error fetching issues:', error);
+      }
     }
   };
   // const updateIssue = async (index, updatedIssue) => {

--- a/frontend/src/stores/scrum/useMeetingStore.js
+++ b/frontend/src/stores/scrum/useMeetingStore.js
@@ -1,7 +1,10 @@
 import { ref } from 'vue';
 import { axiosInstance } from '@/utils/axiosInstance';
 import { defineStore } from 'pinia';
+import { Notyf } from 'notyf';
+import 'notyf/notyf.min.css';
 
+const notyf = new Notyf();
 export const useMeetingStore = defineStore('meetingStore', () => {
   const meetings = ref([]);
   const meetingId = ref(null);
@@ -12,9 +15,18 @@ export const useMeetingStore = defineStore('meetingStore', () => {
         `/api/meeting/${sprintId}`,
         data
       );
-      meetings.value.push(response.data.result);
+      if (response.data.success) {
+        meetings.value.push(response.data.result);
+      } else {
+        notyf.error(response.data.message);
+      }
     } catch (error) {
-      console.error(error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error(error);
+      }
     }
   };
 
@@ -23,9 +35,19 @@ export const useMeetingStore = defineStore('meetingStore', () => {
       const response = await axiosInstance.get(
         `/api/meeting/${workspaceId}/${meetingId}`
       );
-      return response.data.result;
+
+      if (response.data.success) {
+        return response.data.result;
+      } else {
+        notyf.error(response.data.message);
+      }
     } catch (error) {
-      console.error(error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error(error);
+      }
     }
   };
 
@@ -37,7 +59,12 @@ export const useMeetingStore = defineStore('meetingStore', () => {
       meetings.value = response.data.result.content;
       return response.data.result.content;
     } catch (error) {
-      console.error(error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error(error);
+      }
     }
   };
 
@@ -54,7 +81,12 @@ export const useMeetingStore = defineStore('meetingStore', () => {
       });
       return response.data.result;
     } catch (error) {
-      console.error(error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error(error);
+      }
     }
   };
 
@@ -63,7 +95,12 @@ export const useMeetingStore = defineStore('meetingStore', () => {
       const response = await axiosInstance.delete(`/api/meeting/${meetingId}`);
       return response.data.result;
     } catch (error) {
-      console.error(error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error(error);
+      }
     }
   };
 
@@ -85,7 +122,12 @@ export const useMeetingStore = defineStore('meetingStore', () => {
       });
       return response.data.result;
     } catch (error) {
-      console.error(error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error(error);
+      }
     }
   };
 

--- a/frontend/src/stores/scrum/useSprintLabelStore.js
+++ b/frontend/src/stores/scrum/useSprintLabelStore.js
@@ -2,6 +2,10 @@ import { ref } from 'vue';
 import { axiosInstance } from '@/utils/axiosInstance';
 import { defineStore } from 'pinia';
 import { labelColorPalette } from '@/utils/labelUtils';
+import { Notyf } from 'notyf';
+import 'notyf/notyf.min.css';
+
+const notyf = new Notyf();
 
 export const useSprintLabelStore = defineStore('labelStore', () => {
   const labels = ref([]);
@@ -18,9 +22,18 @@ export const useSprintLabelStore = defineStore('labelStore', () => {
         `/api/label/${workspaceId}/sprint`,
         { labelName, description, color }
       );
-      labels.value.push(response.data.result);
+      if (response.data.success) {
+        labels.value.push(response.data.result);
+      } else {
+        notyf.error(response.data.message);
+      }
     } catch (error) {
-      console.error('Error adding label:', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error('Error adding label:', error);
+      }
     }
   };
 
@@ -29,9 +42,19 @@ export const useSprintLabelStore = defineStore('labelStore', () => {
       const response = await axiosInstance.get(
         `/api/label/${workspaceId}/sprint`
       );
-      labels.value = response.data.result;
+
+      if (response.data.success) {
+        labels.value = response.data.result;
+      } else {
+        notyf.error(response.data.message);
+      }
     } catch (error) {
-      console.error('Error fetching labels:', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error('Error fetching labels:', error);
+      }
     }
   };
 
@@ -47,9 +70,19 @@ export const useSprintLabelStore = defineStore('labelStore', () => {
         labelName,
         description,
       });
-      labels.value = response.data.result;
+
+      if (response.data.success) {
+        labels.value = response.data.result;
+      } else {
+        notyf.error(response.data.message);
+      }
     } catch (error) {
-      console.error('Error updating label:', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error('Error updating label:', error);
+      }
     }
   };
 
@@ -58,7 +91,12 @@ export const useSprintLabelStore = defineStore('labelStore', () => {
       await axiosInstance.delete(`/api/label/${workspaceId}/${sprintLabelId}`);
       labels.value = labels.value.filter((label) => label.id !== sprintLabelId);
     } catch (error) {
-      console.error('Error deleting label:', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error('Error deleting label:', error);
+      }
     }
   };
 

--- a/frontend/src/stores/scrum/useSprintStore.js
+++ b/frontend/src/stores/scrum/useSprintStore.js
@@ -2,6 +2,10 @@ import { ref } from 'vue';
 import { axiosInstance } from '@/utils/axiosInstance';
 import { defineStore } from 'pinia';
 import { useRoute } from 'vue-router';
+import { Notyf } from 'notyf';
+import 'notyf/notyf.min.css';
+
+const notyf = new Notyf();
 
 export const useSprintStore = defineStore('sprintStore', () => {
   const sprint = ref([]);
@@ -29,9 +33,19 @@ export const useSprintStore = defineStore('sprintStore', () => {
         startDate,
         endDate,
       });
-      sprints.value.push(response.data.result);
+
+      if (response.data.success) {
+        sprints.value.push(response.data.result);
+      } else {
+        notyf.error(response.data.message);
+      }
     } catch (error) {
-      console.error('Error adding label:', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error('Error adding label:', error);
+      }
     }
   };
 
@@ -43,9 +57,21 @@ export const useSprintStore = defineStore('sprintStore', () => {
       const response = await axiosInstance.get(
         `/api/sprint/${workspaceId}/${sprintId}`
       );
-      sprint.value = response.data.result;
+
+      if (response.data.success) {
+        sprint.value = response.data.result;
+      } else {
+        notyf.error(response.data.message);
+      }
+
+      console.log('응답 코드', response.status);
     } catch (error) {
-      console.log('Error getting Sprint', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.log('Error getting Sprint', error);
+      }
     }
   };
 
@@ -54,9 +80,19 @@ export const useSprintStore = defineStore('sprintStore', () => {
       const response = await axiosInstance.get(
         `/api/sprint/all/${workspaceId}`
       );
-      sprints.value = response.data.result;
+
+      if (response.data.success) {
+        sprints.value = response.data.result;
+      } else {
+        notyf.error(response.data.message);
+      }
     } catch (error) {
-      console.log('Error getting Sprint List', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.log('Error getting Sprint List', error);
+      }
     }
   };
 
@@ -73,9 +109,19 @@ export const useSprintStore = defineStore('sprintStore', () => {
         sprintContents,
         labelId,
       });
-      sprints.value = response.data.result;
+
+      if (response.data.success) {
+        sprints.value = response.data.result;
+      } else {
+        notyf.error(response.data.message);
+      }
     } catch (error) {
-      console.log('Error updating Sprint', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.log('Error updating Sprint', error);
+      }
     }
   };
 
@@ -85,9 +131,19 @@ export const useSprintStore = defineStore('sprintStore', () => {
         `/api/sprint/${sprintId}/status`,
         status
       );
-      sprints.value = response.data.result;
+
+      if (response.data.success) {
+        sprints.value = response.data.result;
+      } else {
+        notyf.error(response.data.message);
+      }
     } catch (error) {
-      console.log('Error updating Sprint State', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.log('Error updating Sprint State', error);
+      }
     }
   };
 
@@ -96,7 +152,12 @@ export const useSprintStore = defineStore('sprintStore', () => {
       await axiosInstance.delete(`/api/sprint/${sprintId}`);
       sprints.value = sprints.value.filter((sprint) => sprint.id !== sprintId);
     } catch (error) {
-      console.error('Error deleting sprint:', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error('Error deleting sprint:', error);
+      }
     }
   };
 

--- a/frontend/src/stores/scrum/useTaskLabelStore.js
+++ b/frontend/src/stores/scrum/useTaskLabelStore.js
@@ -2,6 +2,10 @@ import { ref } from 'vue';
 import { axiosInstance } from '@/utils/axiosInstance';
 import { defineStore } from 'pinia';
 import { labelColorPalette } from '@/utils/labelUtils';
+import { Notyf } from 'notyf';
+import 'notyf/notyf.min.css';
+
+const notyf = new Notyf();
 
 export const useTaskLabelStore = defineStore('labelStore', () => {
   const labels = ref([]);
@@ -18,9 +22,19 @@ export const useTaskLabelStore = defineStore('labelStore', () => {
         `/api/label/${workspaceId}/task`,
         { workspaceId, labelName, description, color }
       );
-      labels.value.push(response.data.result);
+
+      if (response.data.success) {
+        labels.value.push(response.data.result);
+      } else {
+        notyf.error(response.data.message);
+      }
     } catch (error) {
-      console.error('Error adding label:', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error('Error adding label:', error);
+      }
     }
   };
 
@@ -29,9 +43,19 @@ export const useTaskLabelStore = defineStore('labelStore', () => {
       const response = await axiosInstance.get(
         `/api/label/${workspaceId}/task`
       );
-      labels.value = response.data.result;
+
+      if (response.data.success) {
+        labels.value = response.data.result;
+      } else {
+        notyf.error(response.data.message);
+      }
     } catch (error) {
-      console.error('Error fetching labels:', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error('Error fetching labels:', error);
+      }
     }
   };
 
@@ -50,9 +74,19 @@ export const useTaskLabelStore = defineStore('labelStore', () => {
           description,
         }
       );
-      labels.value = response.data.result;
+
+      if (response.data.success) {
+        labels.value = response.data.result;
+      } else {
+        notyf.error(response.data.message);
+      }
     } catch (error) {
-      console.error('Error updating label:', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error('Error updating label:', error);
+      }
     }
   };
 
@@ -61,9 +95,15 @@ export const useTaskLabelStore = defineStore('labelStore', () => {
       await axiosInstance.delete(
         `/api/label/${workspaceId}/task/${taskLabelId}`
       );
+
       labels.value = labels.value.filter((label) => label.id !== taskLabelId);
     } catch (error) {
-      console.error('Error deleting label:', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error('Error deleting label:', error);
+      }
     }
   };
 

--- a/frontend/src/stores/scrum/useTaskStore.js
+++ b/frontend/src/stores/scrum/useTaskStore.js
@@ -1,6 +1,10 @@
 import { ref } from 'vue';
 import { axiosInstance } from '@/utils/axiosInstance';
 import { defineStore } from 'pinia';
+import { Notyf } from 'notyf';
+import 'notyf/notyf.min.css';
+
+const notyf = new Notyf();
 
 export const useTaskStore = defineStore('taskStore', () => {
   const taskData = ref([]);
@@ -9,10 +13,20 @@ export const useTaskStore = defineStore('taskStore', () => {
   const addTask = async (data, sprintId) => {
     try {
       const response = await axiosInstance.post(`/api/task/${sprintId}`, data);
-      console.log(response.data.result);
-      taskData.value.push(response.data.result);
+
+      if (response.data.success) {
+        taskData.value.push(response.data.result);
+        notyf.success('Task가 추가되었습니다.');
+      } else {
+        notyf.error(response.data.message);
+      }
     } catch (error) {
-      console.error('Error adding task:', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('Task 추가에 실패했습니다.');
+        console.error('Error adding task:', error);
+      }
     }
   };
 
@@ -22,45 +36,85 @@ export const useTaskStore = defineStore('taskStore', () => {
         `/api/task/${sprintId}/status/${taskId}`,
         { taskId, status }
       );
-      taskData.value = response.data.result;
+
+      if (response.data.success) {
+        taskData.value = response.data.result;
+      } else {
+        notyf.error(response.data.message);
+      }
     } catch (error) {
-      console.error('Error updating task status:', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error('Error updating task status:', error);
+      }
     }
   };
 
-  const getTask = async ({ sprintId, taskId }) => {
+  const getTask = async ({ workspaceId, sprintId, taskId }) => {
     try {
       const response = await axiosInstance.get(
-        `/api/task/${sprintId}/${taskId}`
+        `/api/task/${workspaceId}/${sprintId}/${taskId}`
       );
-      return response.data.result.result;
+
+      if (response.data.success) {
+        return response.data.result;
+      } else {
+        notyf.error(response.data.message);
+      }
     } catch (error) {
-      console.error('Error getting task:', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error('Error getting task:', error);
+      }
     }
   };
 
-  const getTaskList = async (sprintId) => {
+  const getTaskList = async (workspaceId, sprintId) => {
     try {
       const response = await axiosInstance.get(
-        `/api/task/${sprintId}/all/status`
+        `/api/task/${workspaceId}/${sprintId}/all/status`
       );
-      taskList.value = response.data.result;
-      return response.data.result;
+
+      if (response.data.success) {
+        taskList.value = response.data.result;
+        return response.data.result;
+      } else {
+        notyf.error(response.data.message);
+      }
     } catch (error) {
-      console.error('Error getting task list:', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error('Error getting task list:', error);
+      }
     }
   };
 
   // 유저 별 태스크 칸반 조회
-  const getTaskListByUser = async (sprintId, userId) => {
+  const getTaskListByUser = async (workspaceId, sprintId, userId) => {
     try {
       const response = await axiosInstance.get(
-        `/api/task/${sprintId}/all/status/${userId}`
+        `/api/task/${workspaceId}/${sprintId}/all/status/${userId}`
       );
-      taskList.value = response.data.result;
-      return response.data.result;
+
+      if (response.data.success) {
+        taskList.value = response.data.result;
+        return response.data.result;
+      } else {
+        notyf.error(response.data.message);
+      }
     } catch (error) {
-      console.error('Error getting task list:', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error('Error getting task list:', error);
+      }
     }
   };
 
@@ -69,10 +123,19 @@ export const useTaskStore = defineStore('taskStore', () => {
       const response = await axiosInstance.get(
         `/api/workspace/${workspaceId}/tasks`
       );
-      console.log('API 응답:', response); // 응답 전체 확인
-      return response.data.result; // 응답 데이터 반환
+
+      if (response.data.success) {
+        return response.data.result; // 응답 데이터 반환
+      } else {
+        notyf.error(response.data.message);
+      }
     } catch (error) {
-      console.error('Error getting task list:', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error('Error getting task list:', error);
+      }
       return [];
     }
   };
@@ -96,9 +159,18 @@ export const useTaskStore = defineStore('taskStore', () => {
         labels,
         participants,
       });
-      taskData.value = response.data.result;
+      if (response.data.success) {
+        taskData.value = response.data.result;
+      } else {
+        notyf.error(response.data.message);
+      }
     } catch (error) {
-      console.error('Error updating task:', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error('Error updating task:', error);
+      }
     }
   };
 
@@ -107,18 +179,32 @@ export const useTaskStore = defineStore('taskStore', () => {
       await axiosInstance.delete(`api/task/${sprintId}/${taskId}`);
       taskData.value = taskData.value.filter((task) => task.id !== taskId);
     } catch (error) {
-      console.error('Error deleting task:', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error('Error deleting task:', error);
+      }
     }
   };
 
   const getMyTask = async () => {
     try {
       const response = await axiosInstance.get(`/api/sprint/my/all`);
-      taskData.value = response.data.result;
 
-      return response.data.result;
+      if (response.data.success) {
+        taskData.value = response.data.result;
+        return response.data.result;
+      } else {
+        notyf.error(response.data.message);
+      }
     } catch (error) {
-      console.error('Error getting task list:', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error('Error getting task list:', error);
+      }
     }
   };
 

--- a/frontend/src/stores/workspace/useWorkspaceDashboardStore.js
+++ b/frontend/src/stores/workspace/useWorkspaceDashboardStore.js
@@ -2,6 +2,10 @@ import { ref } from 'vue';
 import { axiosInstance } from '@/utils/axiosInstance';
 import { defineStore } from 'pinia';
 import { weeklySettingUtils } from '@/utils/scheduleDateSettingUtils';
+import { Notyf } from 'notyf';
+import 'notyf/notyf.min.css';
+
+const notyf = new Notyf();
 
 export const useWorkspaceDashboardStore = defineStore(
   'workspaceDashboardStore',
@@ -16,15 +20,25 @@ export const useWorkspaceDashboardStore = defineStore(
         `/api/sprint/all/${workspaceId}`,
         { withCredentials: true }
       );
-      workspaceSprintData.value = response.data.result;
+
+      if (response.data.success) {
+        workspaceSprintData.value = response.data.result;
+      } else {
+        notyf.error(response.data.message);
+      }
     };
 
-    const getWorkspaceMonthly = async ({workspaceId, startDate, endDate}) => {
+    const getWorkspaceMonthly = async ({ workspaceId, startDate, endDate }) => {
       const response = await axiosInstance.get(
         `/api/schedule/${workspaceId}/monthly?startDate=${startDate}&endDate=${endDate}`,
         { withCredentials: true }
       );
-      workspaceMonthlyData.value = response.data.result;
+
+      if (response.data.success) {
+        workspaceMonthlyData.value = response.data.result;
+      } else {
+        notyf.error(response.data.message);
+      }
     };
 
     const getWorkspaceWeekly = async (workspaceId) => {
@@ -33,7 +47,12 @@ export const useWorkspaceDashboardStore = defineStore(
         `/api/schedule/${workspaceId}/weekly?startDate=${startDate}&endDate=${endDate}`,
         { withCredentials: true }
       );
-      workspaceWeeklyData.value = response.data.result;
+
+      if (response.data.success) {
+        workspaceWeeklyData.value = response.data.result;
+      } else {
+        notyf.error(response.data.message);
+      }
     };
 
     const getWorkspaceDashboard = async (workspaceId) => {
@@ -41,8 +60,13 @@ export const useWorkspaceDashboardStore = defineStore(
         `/api/dashboard/${workspaceId}`,
         { withCredentials: true }
       );
-      workspaceDashboardData.value = response.data.result;
-      return response.data.result;
+
+      if (response.data.success) {
+        workspaceDashboardData.value = response.data.result;
+        return response.data.result;
+      } else {
+        notyf.error(response.data.message);
+      }
     };
 
     return {

--- a/frontend/src/stores/workspace/useWorkspaceStore.js
+++ b/frontend/src/stores/workspace/useWorkspaceStore.js
@@ -2,6 +2,10 @@ import { ref } from 'vue';
 import { axiosInstance } from '@/utils/axiosInstance';
 import { defineStore } from 'pinia';
 import { useAlarmStore } from '@/stores/alarm/useAlarmStore';
+import { Notyf } from 'notyf';
+import 'notyf/notyf.min.css';
+
+const notyf = new Notyf();
 
 export const useWorkspaceStore = defineStore('workspaceStore', () => {
   const workspace = ref([]);
@@ -17,10 +21,21 @@ export const useWorkspaceStore = defineStore('workspaceStore', () => {
         participants,
         avatar,
       });
-      workspace.value = response.data.result;
-      return response.data;
+
+      if (response.data.success) {
+        workspace.value = response.data.result;
+        return response.data;
+      } else {
+        notyf.error(response.data.message);
+      }
     } catch (error) {
-      console.error('Failed to add workspace', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error('Failed to add workspace', error);
+      }
+
       throw error;
     }
   };
@@ -34,10 +49,21 @@ export const useWorkspaceStore = defineStore('workspaceStore', () => {
       const response = await axiosInstance.get('/api/workspace/my/all', {
         withCredentials: true,
       });
-      workspace.value = response.data.result;
-      return response.data.result;
+
+      if (response.data.success) {
+        workspace.value = response.data.result;
+        return response.data.result;
+      } else {
+        notyf.error(response.data.message);
+      }
     } catch (error) {
-      console.error('Failed to fetch workspace', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error('Failed to fetch workspace', error);
+      }
+
       return [];
     }
   };
@@ -57,10 +83,21 @@ export const useWorkspaceStore = defineStore('workspaceStore', () => {
           participants,
         }
       );
-      workspace.value = response.data.result;
-      return response.data.result;
+
+      if (response.data.success) {
+        workspace.value = response.data.result;
+        return response.data.result;
+      } else {
+        notyf.error(response.data.message);
+      }
     } catch (error) {
-      console.error('Failed to update workspace', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error('Failed to update workspace', error);
+      }
+
       throw error;
     }
   };
@@ -83,7 +120,13 @@ export const useWorkspaceStore = defineStore('workspaceStore', () => {
 
       return response.data;
     } catch (error) {
-      console.error('Failed to delete workspace', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error('Failed to delete workspace', error);
+      }
+
       throw error;
     }
   };
@@ -115,10 +158,21 @@ export const useWorkspaceStore = defineStore('workspaceStore', () => {
       const response = await axiosInstance.patch(
         `/api/workspace/accept/${workspaceId}`
       );
-      workspace.value = response.data;
-      return response.data;
+
+      if (response.data.success) {
+        workspace.value = response.data;
+        return response.data;
+      } else {
+        notyf.error(response.data.message);
+      }
     } catch (error) {
-      console.error('Failed to accept workspace', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error('Failed to accept workspace', error);
+      }
+
       throw error;
     }
   };
@@ -130,11 +184,22 @@ export const useWorkspaceStore = defineStore('workspaceStore', () => {
       const response = await axiosInstance.delete(
         `/api/workspace/reject/${workspaceId}`
       );
-      workspace.value = response.data;
-      await alarmStore.deleteAlarm(workspaceId);
-      return response.data;
+
+      if (response.data.success) {
+        workspace.value = response.data;
+        await alarmStore.deleteAlarm(workspaceId);
+        return response.data;
+      } else {
+        notyf.error(response.data.message);
+      }
     } catch (error) {
-      console.error('Failed to reject workspace', error);
+      if (error.response && error.response.status === 403) {
+        notyf.error('접근 권한이 없습니다.');
+      } else {
+        notyf.error('알 수 없는 오류가 발생했습니다.');
+        console.error('Failed to reject workspace', error);
+      }
+
       throw error;
     }
   };

--- a/frontend/src/view/scrum/Task/component/TaskViewBar.vue
+++ b/frontend/src/view/scrum/Task/component/TaskViewBar.vue
@@ -44,12 +44,12 @@ onMounted(async () => {
 });
 
 const getTasks = async (sprintId) => {
-  taskLists.value = await taskStore.getTaskList(sprintId);
+  taskLists.value = await taskStore.getTaskList(workspaceId, sprintId);
 };
 
 watch(selectedSprintId, async (newSprintId) => {
   if (newSprintId) {
-    taskLists.value = await taskStore.getTaskList(newSprintId);
+    taskLists.value = await taskStore.getTaskList(workspaceId, newSprintId);
   }
 });
 </script>

--- a/frontend/src/view/scrum/detail/TaskDetailPage.vue
+++ b/frontend/src/view/scrum/detail/TaskDetailPage.vue
@@ -6,6 +6,7 @@ import { useTaskStore } from '@/stores/scrum/useTaskStore';
 const route = useRoute();
 
 const taskId = route.params.tasktId;
+const workspaceId = route.params.workspaceId;
 
 const contentsTitle = inject('contentsTitle');
 const contentsDescription = inject('contentsDescription');
@@ -16,7 +17,7 @@ const taskStore = useTaskStore();
 const task = ref(null);
 
 onMounted(async () => {
-  await taskStore.getTask(taskId);
+  await taskStore.getTask(workspaceId, taskId);
   task.value = taskStore.tasks.values;
 });
 </script>
@@ -46,9 +47,9 @@ onMounted(async () => {
           </span>
           <div class="users-list">
             <div
-                class="user-profile"
-                v-for="participant in task.value.participants"
-                :key="participant.id"
+              class="user-profile"
+              v-for="participant in task.value.participants"
+              :key="participant.id"
             >
               <img :src="participant.avatar" alt="참여자" />
               <span>{{ participant.name }}</span>
@@ -63,9 +64,9 @@ onMounted(async () => {
         </span>
         <div class="label-list">
           <button
-              class="label-button"
-              v-for="label in task.value.labels"
-              :key="label.id"
+            class="label-button"
+            v-for="label in task.value.labels"
+            :key="label.id"
           >
             {{ label.name }}
           </button>


### PR DESCRIPTION
## 연관된 이슈
<!-- 관련된 이슈 번호를 적어주세요 -->
<br>

## 작업 내용
<!-- 작업에 대한 설명을 적어주세요 -->
- api 요청에서 받은 응답에 따른 예외처리를 했습니다. 특히 자주 발생하는 403 forbidden 상태와 상태코드가 200이더라도 예외처리 된 값일 경우가 있으므로 해당 상황을 모두 알람으로 띄우도록 수정했습니다.
- 태스크 생성 시 백엔드에서 요구하는 타입과 프론트에서 요청 보내는 타입이 맞지 않아 400 에러가 발생했습니다. 필요한 값으로 매핑하여 전달하도록 수정했습니다. 
- 태스크 조회 시 스프린트의 참여 여부에 따라 권한을 확인하면 너무 잦은 페이지에 권한 없음이 뜨기 때문에, 조회에 한해서 권한을 갖도록 수정했고 이에 따라 워크스페이스 아이디를 매개변수로 전달하도록 수정했습니다.
<br> 

## 전달 사항
<!-- 참고할 사항이 있다면 알려주세요 -->
최대한 다양한 상황을 테스트하고 보내나, 혹시 빠진 부분이 있을 수도 있습니다. 혹시 오류가 발생하면 알려주세요.
꼭 풀 받고 작업해주세요!