### PR TITLE
[Feat] 드래그 앤 드랍 시 상태 변경 기능 구현

### DIFF
--- a/frontend/src/stores/scrum/useSprintStore.js
+++ b/frontend/src/stores/scrum/useSprintStore.js
@@ -11,6 +11,7 @@ export const useSprintStore = defineStore('sprintStore', () => {
   const sprint = ref([]);
   const sprints = ref([]);
   const sprintId = ref(null);
+  const nowSprintId = ref(null);
 
   const route = useRoute();
 
@@ -174,10 +175,15 @@ export const useSprintStore = defineStore('sprintStore', () => {
     }
   };
 
+  const setNowSprintId = (id) => {
+    nowSprintId.value = id;
+  };
+
   return {
     sprint,
     sprints,
     sprintId,
+    nowSprintId,
     addSprint,
     getSprint,
     getSprintList,
@@ -185,5 +191,6 @@ export const useSprintStore = defineStore('sprintStore', () => {
     updateSprintState,
     deleteSprint,
     setSprintId,
+    setNowSprintId,
   };
 });

--- a/frontend/src/stores/scrum/useTaskStore.js
+++ b/frontend/src/stores/scrum/useTaskStore.js
@@ -30,7 +30,7 @@ export const useTaskStore = defineStore('taskStore', () => {
     }
   };
 
-  const updateTaskStatus = async ({ sprintId, taskId, status }) => {
+  const updateTaskStatus = async (sprintId, taskId, status) => {
     try {
       const response = await axiosInstance.patch(
         `/api/task/${sprintId}/status/${taskId}`,

--- a/frontend/src/view/scrum/Task/component/TaskViewBar.vue
+++ b/frontend/src/view/scrum/Task/component/TaskViewBar.vue
@@ -44,11 +44,13 @@ onMounted(async () => {
 });
 
 const getTasks = async (sprintId) => {
+  sprintStore.setNowSprintId(sprintId);
   taskLists.value = await taskStore.getTaskList(workspaceId, sprintId);
 };
 
 watch(selectedSprintId, async (newSprintId) => {
   if (newSprintId) {
+    sprintStore.setNowSprintId(newSprintId);
     taskLists.value = await taskStore.getTaskList(workspaceId, newSprintId);
   }
 });

--- a/frontend/src/view/scrum/Task/kanban/WorkSpaceTaskKanbanPage.vue
+++ b/frontend/src/view/scrum/Task/kanban/WorkSpaceTaskKanbanPage.vue
@@ -3,6 +3,9 @@ import { inject, ref, watch, onMounted, computed } from 'vue';
 import TaskColumn from './component/KanbanColumn.vue';
 import { useTaskStore } from '@/stores/scrum/useTaskStore';
 import { useRoute } from 'vue-router';
+import { useSprintStore } from '@/stores/scrum/useSprintStore';
+
+const sprintStore = useSprintStore();
 
 const reorderTasksByStatus = (tasksArray) => {
   if (!tasksArray) return []; // tasksArray가 null 또는 undefined일 경우 빈 배열 반환
@@ -22,6 +25,13 @@ const reorderTasksByStatus = (tasksArray) => {
     { IN_PROGRESS: reorderedTasks.IN_PROGRESS },
     { DONE: reorderedTasks.DONE },
   ];
+};
+
+const fetchTasks = async () => {
+  tasksByStatus.value = await taskStore.getTaskList(
+    workspaceId,
+    sprintStore.nowSprintId
+  );
 };
 
 const contentsTitle = inject('contentsTitle');
@@ -62,6 +72,7 @@ const hasTasks = computed(() => {
         v-for="task in reorderTasksByStatus(tasksByStatus)"
         :key="task.key"
         :data="task"
+        @taskUpdated="fetchTasks"
       />
     </div>
     <div class="initial-wrap" v-else>


### PR DESCRIPTION
## 연관된 이슈
<!-- 관련된 이슈 번호를 적어주세요 -->
<br>

## 작업 내용
<!-- 작업에 대한 설명을 적어주세요 -->
- 칸반 보드에서 태스크를 드래그 앤 드롭할 때, 새로운 상태로 변경하는 API를 호출하여 서버에 반영되도록 구현했습니다. 이를 위해 현재 선택한 스프린트 ID를 스토어에 저장하도록 수정했습니다.
- 하위 컴포넌트에서 드래그 앤 드롭 이벤트가 발생하면 상위 컴포넌트로 이벤트를 전달하여, 태스크 리스트를 다시 불러올 수 있도록 구현했습니다.
- 드래그 대상의 상태를 파악하기 위해 item-key 속성을 상태 이름으로 설정하고, 태스크 카드의 ID를 DOM의 id 속성으로 추가하여 드래그 이벤트 시 상태와 ID를 쉽게 가져올 수 있도록 했습니다.
<br> 

## 전달 사항
<!-- 참고할 사항이 있다면 알려주세요 -->
드래그 했을 때, 태스크 재정렬 및 데이터 fetch 시간 때문에 깜빡임이 있습니다. 추후 수정이 필요합니다.