### PR TITLE
[Fix] 에러 상세 조회 수정

### DIFF
--- a/frontend/src/common/component/Board/BoardList.vue
+++ b/frontend/src/common/component/Board/BoardList.vue
@@ -1,7 +1,7 @@
 <script setup>
-import { defineProps} from 'vue';
-import router from "@/router";
-import {useRoute} from "vue-router";
+import { defineProps } from 'vue';
+import router from '@/router';
+import { useRoute } from 'vue-router';
 
 const route = useRoute();
 const workspaceId = route.params.workspaceId;
@@ -15,11 +15,11 @@ defineProps({
 
 function navigateToDetailPage(item) {
   router.push({
-    name: 'ErrorDetailPage',
+    name: 'ErrorDetail',
     params: {
       workspaceId: workspaceId,
       boardId: item.errorBoardId,
-    }
+    },
   });
 }
 </script>
@@ -27,37 +27,44 @@ function navigateToDetailPage(item) {
 <template>
   <table class="board-table">
     <thead>
-    <tr>
-      <th>게시글 제목</th>
-      <th>작성자</th>
-      <th>{{thcolumn}}</th>
-      <th>작성 시간</th>
-      <th></th>
-    </tr>
+      <tr>
+        <th>게시글 제목</th>
+        <th>작성자</th>
+        <th>{{ thcolumn }}</th>
+        <th>작성 시간</th>
+        <th></th>
+      </tr>
     </thead>
     <tbody>
-    <tr v-for="(item, index) in items" :key="index" @click="navigateToDetailPage">
-      <td class="title">{{ item.errboardTitle  }}</td>
-      <td>{{ item.userName  }}</td>
-      <td>{{ item.errboardCategory }}</td>
-      <td>{{ new Date(item.createdAt).toLocaleString() }}</td>
-      <td class="action-bundle">
-        <button @click="$emit('edit-item', item)" class="action-btn edit-btn">
-          <i class="edit-icon"></i>
-        </button>
-        <button @click="$emit('delete-item', item)" class="action-btn delete-btn">
-          <i class="delete-icon"></i>
-        </button>
-      </td>
-    </tr>
+      <tr
+        v-for="(item, index) in items"
+        :key="index"
+        @click="navigateToDetailPage(item)"
+      >
+        <td class="title">{{ item.errboardTitle }}</td>
+        <td>{{ item.userName }}</td>
+        <td>{{ item.errboardCategory }}</td>
+        <td>{{ new Date(item.createdAt).toLocaleString() }}</td>
+        <td class="action-bundle">
+          <button @click="$emit('edit-item', item)" class="action-btn edit-btn">
+            <i class="edit-icon"></i>
+          </button>
+          <button
+            @click="$emit('delete-item', item)"
+            class="action-btn delete-btn"
+          >
+            <i class="delete-icon"></i>
+          </button>
+        </td>
+      </tr>
     </tbody>
   </table>
 </template>
 
 <style scoped>
-a{
+a {
   text-decoration: none;
-  color: #28303F;
+  color: #28303f;
 }
 
 .board-table {
@@ -70,35 +77,35 @@ a{
 .board-table td {
   padding: 10px;
   text-align: center;
-  border-bottom: 1px solid #E6E9F4;
+  border-bottom: 1px solid #e6e9f4;
 }
 
 .board-table th {
   background-color: #fff;
   font-size: 14px;
   font-weight: 400;
-  color: #5A607F;
+  color: #5a607f;
 }
 
-input[type="checkbox"]{
+input[type='checkbox'] {
   display: none;
 }
-input[type="checkbox"] + label{
+input[type='checkbox'] + label {
   display: inline-block;
   width: 20px;
   height: 20px;
-  border:1px solid #D7DBEC;
+  border: 1px solid #d7dbec;
   position: relative;
 }
-input[id="check"]:checked + label::after{
-  content:'✔';
+input[id='check']:checked + label::after {
+  content: '✔';
   font-size: 15px;
   width: 20px;
   height: 20px;
   text-align: center;
   position: absolute;
   left: 0;
-  top:0;
+  top: 0;
 }
 
 .title {
@@ -121,12 +128,12 @@ input[id="check"]:checked + label::after{
   width: 40px;
   height: 40px;
   display: block;
-  background-image: url("@/assets/icon/boardIcon/boardEdit.svg");
+  background-image: url('@/assets/icon/boardIcon/boardEdit.svg');
 }
 .delete-icon {
   width: 40px;
   height: 40px;
   display: block;
-  background-image: url("@/assets/icon/boardIcon/boardDelete.svg");
+  background-image: url('@/assets/icon/boardIcon/boardDelete.svg');
 }
 </style>

--- a/frontend/src/common/component/Board/ErrorBoardDetail.vue
+++ b/frontend/src/common/component/Board/ErrorBoardDetail.vue
@@ -1,16 +1,17 @@
 <script setup>
 import { computed, defineProps } from 'vue';
 
-defineProps({
+const props = defineProps({
   title: String,
   status: String,
   subheading: String,
   descriptionList: Array,
   owner: String,
+  taskName: String,
 });
 
 const statusClass = computed(() => {
-  return status === 'In Progress' ? 'in-progress' : 'done';
+  return props.status === 'In Progress' ? 'in-progress' : 'done';
 });
 </script>
 
@@ -23,11 +24,18 @@ const statusClass = computed(() => {
     <div class="description">
       <p class="sub-heading">{{ subheading }}</p>
       <ul>
-        <li v-for="(item, index) in descriptionList" :key="index" class="description-content">{{ item }}</li>
+        <li
+          v-for="(item, index) in descriptionList"
+          :key="index"
+          class="description-content"
+        >
+          {{ item }}
+        </li>
       </ul>
     </div>
     <div class="footer">
       <p><strong>담당자:</strong> {{ owner }}</p>
+      <p><strong>관련 태스크:</strong> {{ taskName }}</p>
     </div>
   </div>
 </template>
@@ -63,7 +71,7 @@ const statusClass = computed(() => {
   margin: 0;
 }
 
-.description-content{
+.description-content {
   font-size: 14px;
   margin-top: 10px;
 }

--- a/frontend/src/common/component/Board/QABoardList.vue
+++ b/frontend/src/common/component/Board/QABoardList.vue
@@ -1,8 +1,8 @@
 <script setup>
 import { defineProps } from 'vue';
-import { useRoute } from "vue-router";
-import { formatDate } from "@/utils/timeUtils";
-import router from "@/router";
+import { useRoute } from 'vue-router';
+import { formatDate } from '@/utils/timeUtils';
+import router from '@/router';
 
 const route = useRoute();
 const workspaceId = route.params.workspaceId;
@@ -15,39 +15,45 @@ defineProps({
 });
 
 function navigateToDetailPage(item) {
-    router.push(`/workspace/${workspaceId}/scrum/board/qa/detail/${item.qaBoardId}`);
+  router.push(
+    `/workspace/${workspaceId}/scrum/board/qa/detail/${item.qaBoardId}`
+  );
 }
 </script>
 
 <template>
   <table class="board-table">
     <thead>
-    <tr>
-      <th>게시글 제목</th>
-      <th>내용</th>
-      <th>Task</th>
-      <th>담당자</th>
-      <th>작성자</th>
-      <th>작성 시간</th>
-    </tr>
+      <tr>
+        <th>게시글 제목</th>
+        <th>내용</th>
+        <th>Task</th>
+        <th>담당자</th>
+        <th>작성자</th>
+        <th>작성 시간</th>
+      </tr>
     </thead>
     <tbody>
-    <tr v-for="(item, index) in items" :key="index" @click="navigateToDetailPage(item)">
-        <td class="title">{{ item.qaboardTitle  }}</td>
-          <td>{{ item.qaboardContent }}</td>
-        <td>{{ item.taskName  }}</td>
+      <tr
+        v-for="(item, index) in items"
+        :key="index"
+        @click="navigateToDetailPage(item)"
+      >
+        <td class="title">{{ item.qaboardTitle }}</td>
+        <td>{{ item.qaboardContent }}</td>
+        <td>{{ item.taskName }}</td>
         <td>{{ item.assignUser }}</td>
         <td>{{ item.userName }}</td>
         <td>{{ formatDate(item.createdAt) }}</td>
-    </tr>
+      </tr>
     </tbody>
   </table>
 </template>
 
 <style scoped>
-a{
+a {
   text-decoration: none;
-  color: #28303F;
+  color: #28303f;
 }
 
 .board-table {
@@ -60,35 +66,35 @@ a{
 .board-table td {
   padding: 10px;
   text-align: center;
-  border-bottom: 1px solid #E6E9F4;
+  border-bottom: 1px solid #e6e9f4;
 }
 
 .board-table th {
   background-color: #fff;
   font-size: 14px;
   font-weight: 400;
-  color: #5A607F;
+  color: #5a607f;
 }
 
-input[type="checkbox"]{
+input[type='checkbox'] {
   display: none;
 }
-input[type="checkbox"] + label{
+input[type='checkbox'] + label {
   display: inline-block;
   width: 20px;
   height: 20px;
-  border:1px solid #D7DBEC;
+  border: 1px solid #d7dbec;
   position: relative;
 }
-input[id="check"]:checked + label::after{
-  content:'✔';
+input[id='check']:checked + label::after {
+  content: '✔';
   font-size: 15px;
   width: 20px;
   height: 20px;
   text-align: center;
   position: absolute;
   left: 0;
-  top:0;
+  top: 0;
 }
 
 .title {
@@ -111,12 +117,12 @@ input[id="check"]:checked + label::after{
   width: 40px;
   height: 40px;
   display: block;
-  background-image: url("@/assets/icon/boardIcon/boardEdit.svg");
+  background-image: url('@/assets/icon/boardIcon/boardEdit.svg');
 }
 .delete-icon {
   width: 40px;
   height: 40px;
   display: block;
-  background-image: url("@/assets/icon/boardIcon/boardDelete.svg");
+  background-image: url('@/assets/icon/boardIcon/boardDelete.svg');
 }
 </style>

--- a/frontend/src/stores/board/useErrorStore.js
+++ b/frontend/src/stores/board/useErrorStore.js
@@ -1,62 +1,113 @@
+import { axiosInstance } from '@/utils/axiosInstance';
 import { defineStore } from 'pinia';
-import { axiosInstance } from '@/utils/axiosInstance';  // axiosInstance를 가져옵니다
+import { ref } from 'vue';
 
-export const useErrorStore = defineStore('errorBoard', {
-  state: () => ({
-    errorBoards: [],  // 게시판 리스트를 저장하는 상태
-  }),
-  actions: {
-    // 게시글 생성
-    async getErrorBoardList(workspaceId, page, size) {
-      try {
-        const response = await axiosInstance.get('/api/errboard/search-all', {
-          params: { workspaceId: workspaceId, page: page - 1, size: size }
-        });
-        this.errorBoards = response.data.result.content;
-        return this.errorBoards;
-      } catch (error) {
-        console.error('게시글 목록 조회 중 오류가 발생했습니다:', error);
-        throw error;
-      }
-    },
-    
-    // 게시글 하나 조회
-    async getErrorBoard(boardId) {
-      try {
-        const response = await axiosInstance.get('/api/errboard/search', {
-          params: { boardId }
-        });
-        return response.data.result;
-      } catch (error) {
-        console.error('게시글 조회 중 오류가 발생했습니다:', error);
-        throw error;
-      }
-    },
-    
-    // 키워드로 게시글 검색
-    async searchErrorBoardByKeyword(workspaceId, page, size, keyword) {
-      try {
-        const response = await axiosInstance.get('/api/errboard/search-keyword', {
-          params: { workspaceId, page, size, keyword }
-        });
-        return response.data.result.content;
-      } catch (error) {
-        console.error('키워드로 게시글 검색 중 오류가 발생했습니다:', error);
-        throw error;
-      }
-    },
+export const useErrorStore = defineStore('errorBoard', () => {
+  const errorBoards = ref([]);
+  const errorDetail = ref({});
 
-    // 카테고리별로 게시글 검색
-    async searchErrorBoardByCategory(workspaceId, page, size, category) {
-      try {
-        const response = await axiosInstance.get('/api/errboard/search-category', {
-          params: { workspaceId, page, size, category }
-        });
-        return response.data.result.content;
-      } catch (error) {
-        console.error('카테고리별 게시글 검색 중 오류가 발생했습니다:', error);
-        throw error;
-      }
+  // [GET] 게시글 목록 조회
+  const getErrorBoardList = async (workspaceId, page, size) => {
+    try {
+      page = page - 1; // 페이지 번호를 0부터 시작하도록 조정
+      const response = await axiosInstance.get('/api/errboard/search-all', {
+        params: { workspaceId, page, size },
+      });
+      errorBoards.value = response.data.result.content;
+      return errorBoards.value;
+    } catch (error) {
+      console.error('게시글 목록 조회 중 오류가 발생했습니다:', error);
+      return error.response?.data || { message: 'Unknown error occurred' };
     }
-  }
+  };
+
+  // [GET] 게시글 상세 조회
+  const getErrorBoard = async (boardId) => {
+    try {
+      const response = await axiosInstance.get('/api/errboard/search', {
+        params: { boardId },
+      });
+      errorDetail.value = response.data.result;
+      return response.data.result;
+    } catch (error) {
+      console.error('게시글 조회 중 오류가 발생했습니다:', error);
+      return error.response?.data || { message: 'Unknown error occurred' };
+    }
+  };
+
+  // [GET] 키워드로 게시글 검색
+  const searchErrorBoardByKeyword = async (
+    workspaceId,
+    page,
+    size,
+    keyword
+  ) => {
+    try {
+      const response = await axiosInstance.get('/api/errboard/search-keyword', {
+        params: { workspaceId, page, size, keyword },
+      });
+      errorBoards.value = response.data.result.content;
+      return errorBoards.value;
+    } catch (error) {
+      console.error('키워드로 게시글 검색 중 오류가 발생했습니다:', error);
+      return error.response?.data || { message: 'Unknown error occurred' };
+    }
+  };
+
+  // [GET] 카테고리별로 게시글 검색
+  const searchErrorBoardByCategory = async (
+    workspaceId,
+    page,
+    size,
+    category
+  ) => {
+    try {
+      const response = await axiosInstance.get(
+        '/api/errboard/search-category',
+        {
+          params: { workspaceId, page, size, category },
+        }
+      );
+      errorBoards.value = response.data.result.content;
+      return errorBoards.value;
+    } catch (error) {
+      console.error('카테고리별 게시글 검색 중 오류가 발생했습니다:', error);
+      return error.response?.data || { message: 'Unknown error occurred' };
+    }
+  };
+
+  // [PUT] 게시글 업데이트
+  const updateErrorBoard = async (data) => {
+    try {
+      const response = await axiosInstance.put('/api/errboard/update', data);
+      return response.data.result;
+    } catch (error) {
+      console.error('게시글 업데이트 중 오류가 발생했습니다:', error);
+      return error.response?.data || { message: 'Unknown error occurred' };
+    }
+  };
+
+  // [DELETE] 게시글 삭제
+  const deleteErrorBoard = async (id) => {
+    try {
+      const response = await axiosInstance.delete('/api/errboard/delete', {
+        data: { id },
+      });
+      return response.data.result;
+    } catch (error) {
+      console.error('게시글 삭제 중 오류가 발생했습니다:', error);
+      return error.response?.data || { message: 'Unknown error occurred' };
+    }
+  };
+
+  return {
+    errorBoards,
+    errorDetail,
+    getErrorBoardList,
+    getErrorBoard,
+    searchErrorBoardByKeyword,
+    searchErrorBoardByCategory,
+    updateErrorBoard,
+    deleteErrorBoard,
+  };
 });

--- a/frontend/src/view/board/component/DateComment.vue
+++ b/frontend/src/view/board/component/DateComment.vue
@@ -1,9 +1,10 @@
 <script setup>
 import { computed, defineProps } from 'vue';
+import { formatDate } from '@/utils/timeUtils';
 
 const props = defineProps({
   date: String,
-  comments: Number
+  comments: Number,
 });
 
 const formattedDate = computed(() => {
@@ -13,7 +14,7 @@ const formattedDate = computed(() => {
 
 <template>
   <div class="date-comment">
-    <span class="date">{{ formattedDate }}</span>
+    <span class="date">{{ formatDate(formattedDate) }}</span>
     <div class="comments">
       <i class="comment-icon"></i>
       <span class="comment-count">{{ comments }}</span>
@@ -41,7 +42,7 @@ const formattedDate = computed(() => {
 }
 
 .comment-icon {
-  background-image: url("@/assets/icon/boardIcon/boardComment.svg");
+  background-image: url('@/assets/icon/boardIcon/boardComment.svg');
   width: 24px;
   height: 24px;
   margin-right: 5px;

--- a/frontend/src/view/board/detail/ErrorDetailPage.vue
+++ b/frontend/src/view/board/detail/ErrorDetailPage.vue
@@ -1,10 +1,10 @@
 <script setup>
-import BoardDetail from "@/common/component/Board/ErrorBoardDetail.vue";
-import {inject} from "vue";
+import { ref, inject, onMounted } from 'vue';
+import BoardDetail from '@/common/component/Board/ErrorBoardDetail.vue';
 import { useRoute } from 'vue-router';
-import { useErrorStore } from "@/stores/board/useErrorStore";
-import DateComment from "@/view/board/component/DateComment.vue";
-import CommentComponent from "@/view/board/detail/componenet/CommentComponent.vue";
+import { useErrorStore } from '@/stores/board/useErrorStore';
+import DateComment from '@/view/board/component/DateComment.vue';
+import CommentComponent from '@/view/board/detail/componenet/CommentComponent.vue';
 
 const contentsTitle = inject('contentsTitle');
 const contentsDescription = inject('contentsDescription');
@@ -15,37 +15,50 @@ contentsDescription.value = 'Error를 확인하세요!';
 const errorStore = useErrorStore();
 const route = useRoute();
 const boardId = route.params.boardId;
+const postDetail = ref(null);
+const loading = ref(true); // 로딩 상태 추가
 
 const fetchErrorDetail = async () => {
-  const postDetail = await errorStore.getPostDetail(boardId);
-  contentsTitle.value = postDetail.title || 'Error 상세 보기';
-  contentsDescription.value = postDetail.description || 'Error를 확인하세요!';
+  const detail = await errorStore.getErrorBoard(boardId);
+  postDetail.value = detail;
+  contentsTitle.value = detail.title || 'Error 상세 보기';
+  contentsDescription.value = detail.description || 'Error를 확인하세요!';
+  loading.value = false; // 로딩 완료
 };
 
-fetchErrorDetail();
+onMounted(fetchErrorDetail);
 </script>
 
 <template>
-  <div class="error-detail-container">
+  <div v-if="loading" class="loading-indicator">
+    <p>로딩 중...</p>
+  </div>
+  <div v-else class="error-detail-container">
     <div>
       <BoardDetail
-          :title="errorStore.postDetail.title"
-          :language="errorStore.postDetail.language"
-          :subheading="errorStore.postDetail.subheading"
-          :descriptionList="errorStore.postDetail.descriptionList"
-          :owner="errorStore.postDetail.owner"
+        :title="postDetail.errboardTitle"
+        :status="postDetail.errboardCategory"
+        :subheading="postDetail.errboardContent"
+        :descriptionList="postDetail.getErrorBoardImageResponsesList"
+        :owner="postDetail.userName"
+        :taskName="postDetail.taskName"
       />
       <DateComment
-          :date="errorStore.postDetail.date"
-          :comments="errorStore.postDetail.comments"
+        :date="postDetail.createdAt"
+        :comments="postDetail.comments"
       />
     </div>
-    <CommentComponent/>
+    <CommentComponent />
   </div>
 </template>
 
 <style scoped>
-.error-detail-container{
+.error-detail-container {
   padding: 30px;
+}
+.loading-indicator {
+  text-align: center;
+  padding: 50px;
+  font-size: 18px;
 }
 </style>


### PR DESCRIPTION
## 연관된 이슈
<!-- 관련된 이슈 번호를 적어주세요 -->
<br>

## 작업 내용
<!-- 작업에 대한 설명을 적어주세요 -->
- 에러 상세 페이지 조회 시 발생하던 문제들을 수정했습니다.
   - router 설정에서 라우트 이름이 index.js와 일치하지 않아, 이름을 맞추고 누락된 파라미터를 추가했습니다.
   - ErrorBoardDetail.vue 컴포넌트에서 사용된 키 값들이 API 명세서와 달라 데이터를 정상적으로 불러오지 못하는 문제를 해결했습니다.
   - 기존에 QaStore의 메서드를 호출하도록 되어 있던 부분을 ErrorBoard 메서드로 수정하여, 올바른 스토어의 데이터를 참조하도록 변경했습니다.
- 코드 일관성을 유지하기 위해 ErrorBoard 스토어를 Composition API 방식으로 리팩토링했습니다.
- 데이터를 불러오는 동안 로딩 상태를 표시하도록 수정했습니다. 데이터가 오기 전에 loading 메시지를 띄우고, 데이터를 가져온 후에 실제 내용을 렌더링하도록 구현했습니다.
<br> 

## 전달 사항
<!-- 참고할 사항이 있다면 알려주세요 -->
