### PR TITLE
[Feat] 나의 태스크 상태 변경 구현

### DIFF
--- a/backend/api-server/src/main/java/minionz/apiserver/common/responses/BaseResponseStatus.java
+++ b/backend/api-server/src/main/java/minionz/apiserver/common/responses/BaseResponseStatus.java
@@ -40,7 +40,8 @@ public enum BaseResponseStatus {
     MY_WEEKLY_READ_SUCCESS(true, 3003, "나의 주간 캘린더 조회에 성공했습니다."),
     MY_DASHBOARD_READ_SUCCESS(true, 3004, "나의 대시보드 조회에 성공했습니다."),
     MY_ALARM_READ_SUCCESS(true, 3005, "나의 알람 조회에 성공했습니다."),
-
+    MY_TASK_READ_SUCCESS(true, 3006, "나의 태스크 목록 조회를 성공했습니다."),
+    MY_TASK_CHANGE_STATUS_SUCCESS(true, 3007, "나의 태스크 상태 변경을 성공했습니다."),
 
     /**
      * 4000: 워크스페이스
@@ -78,6 +79,7 @@ public enum BaseResponseStatus {
     NOTE_LABEL_SEARCH_SUCCESS(true,4030,"회의록 라벨 조회에 성공했습니다."),
     TASK_READ_ALL_BY_STATUS_SUCCESS(true, 4031, "태스크 목록을 상태 별 조회에 성공했습니다."),
     NOTE_SAVE_SUCCESS(true,4032,"회의록 저장에 성공했습니다."),
+
 
     WORKSPACE_ACCESS_DENIED(false, 4101, "워크스페이스에 접근 권한이 없습니다."),
     WORKSPACE_NOT_EXISTS(false, 4102, "존재하지 않는 워크스페이스입니다."),

--- a/backend/api-server/src/main/java/minionz/apiserver/scrum/task/TaskController.java
+++ b/backend/api-server/src/main/java/minionz/apiserver/scrum/task/TaskController.java
@@ -106,7 +106,7 @@ public class TaskController {
             return new BaseResponse<>(e.getStatus());
         }
 
-        return new BaseResponse<>(BaseResponseStatus.TASK_READ_ALL_SUCCESS, response);
+        return new BaseResponse<>(BaseResponseStatus.MY_TASK_READ_SUCCESS, response);
     }
 
     @PatchMapping("/{sprintId}/status/{taskId}")
@@ -120,6 +120,19 @@ public class TaskController {
         }
 
         return new BaseResponse<>(BaseResponseStatus.TASK_STATUS_UPDATE_SUCCESS);
+    }
+
+    @PatchMapping("/my/status/{taskId}")
+    public BaseResponse<BaseResponseStatus> updateMyTaskStatus(@PathVariable Long taskId,
+                                                             @RequestBody UpdateTaskStatusRequest request) {
+
+        try {
+            taskService.updateTaskStatus(taskId, request);
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+
+        return new BaseResponse<>(BaseResponseStatus.MY_TASK_CHANGE_STATUS_SUCCESS);
     }
 
 }


### PR DESCRIPTION
## 연관된 이슈
<!-- 관련된 이슈 번호를 적어주세요 -->
<br>

## 작업 내용
<!-- 작업에 대한 설명을 적어주세요 -->
- 워크스페이스 드래그 앤 드랍을 할 때는 해당 스프린트에 참여했는 지에 대한 권한으로 확인합니다. 그러나 마이 스페이스는 이미 권한을 확인하여 반환한 태스크에 대한 것들이기 때문에 권한을 스프린트로 확인하지 않도록 추가 구현했습니다.

<br> 

## 전달 사항
<!-- 참고할 사항이 있다면 알려주세요 -->
